### PR TITLE
Subtasks, detailed output and other improvements

### DIFF
--- a/src/analyze_logs.py
+++ b/src/analyze_logs.py
@@ -208,7 +208,8 @@ if __name__ == "__main__":
                        event_info,
                        host_info,
                        format_file,
-                       args.additive)
+                       args.additive,
+                       output_directory)
     output_descriptor.write('Reading file\'s time range...\n')
     logs.read_time_ranges()
     output_descriptor.write('Searching for running VMs and hosts...\n')
@@ -286,6 +287,7 @@ if __name__ == "__main__":
     output_descriptor.write('Loading data...\n')
     logs.load_data(args.warn, args.progressbar)
     output_descriptor.write('Analyzing the messages...\n')
+    logs.merge_all_messages()
     messages, new_fields = logs.find_important_events()
     output_descriptor.write('Printing messages...\n')
     # Output file

--- a/src/analyze_logs.py
+++ b/src/analyze_logs.py
@@ -88,8 +88,17 @@ if __name__ == "__main__":
                              'process')
     parser.add_argument('--additive',
                         action='store_true',
-                        help='Show full-screen progress bar for parsing ' +
-                             'process')
+                        help='Search for messages that contain user-defined' +
+                             'VMs OR hosts')
+    parser.add_argument('--criterias',
+                        type=str,
+                        nargs='+',
+                        help='Criterias of adding a message to the output.' +
+                             ' Available: "VM id", "Subtasks", ' +
+                             '"Error or warning", "Differ by VM ID", ' +
+                             '"Exclude frequent messages", "Coverage", ' +
+                             '"Increased errors", "Long operations". ' +
+                             'Default is all')
     # parser.add_argument("-chart", "--chart_filename",
     #                    type=str,
     #                    help="Create html file with chart" +
@@ -198,11 +207,16 @@ if __name__ == "__main__":
         format_file = args.format_file
     else:
         format_file = os.path.join("format_templates.txt")
+    if args.criterias is not None:
+        criterias = args.criterias
+    else:
+        criterias = ['All']
     # Start algo
     logs = LogAnalyzer(output_descriptor,
                        args.log_directory,
                        files,
                        tz_info,
+                       criterias,
                        time_range_info,
                        vm_info,
                        event_info,

--- a/src/lib/LogAnalyzer.py
+++ b/src/lib/LogAnalyzer.py
@@ -27,7 +27,7 @@ class LogAnalyzer:
     # log_file_format{"log1":...,}
     # all_errors{"log1":...,}
     # format_fields{'log1':...}
-    def __init__(self, out_descr, directory, filenames, tz,
+    def __init__(self, out_descr, directory, filenames, tz, criterias,
                  time_ranges, user_vms, user_events, user_hosts,
                  templates_filename, additive_link, output_dir):
         self.out_descr = out_descr
@@ -38,6 +38,14 @@ class LogAnalyzer:
         self.user_events = user_events
         self.user_hosts = user_hosts
         self.additive_link = additive_link
+        if len(criterias) == 1 and criterias[0] == 'All':
+            self.criterias = ['VM id', 'Host id', 'Event', 'Subtasks',
+                              'Error or warning',
+                              'Differ by VM ID', 'Exclude frequent messages',
+                              'Coverage', 'Increased errors',
+                              'Long operations']
+        else:
+            self.criterias = criterias
         # parse formats file
         formats = open(templates_filename, 'r').read().split('\n')
         self.formats_templates = []
@@ -112,27 +120,65 @@ class LogAnalyzer:
 
     def find_vms_and_hosts(self):
         self.all_vms, self.all_hosts, self.not_running_vms, \
-        self.not_found_vmnames, self.not_found_hostnames, self.positions = \
-            find_all_vm_host(self.positions, self.out_descr,
-                             self.directory, self.found_logs,
-                             self.time_zones, self.time_ranges)
+        self.not_found_vmnames, self.not_found_hostnames, \
+        self.positions, vm_timeline =  find_all_vm_host(self.positions,
+                                                        self.out_descr,
+                                                        self.output_dir,
+                                                        self.directory,
+                                                        self.found_logs,
+                                                        self.time_zones,
+                                                        self.time_ranges)
         if self.user_vms == []:
             for k in self.all_vms.keys():
                 self.user_vms += [k]
                 for i in self.all_vms[k]['id']:
                     self.user_vms += [i]
-        self.user_vms += self.not_running_vms
-        self.user_vms += self.not_found_vmnames
+            self.user_vms += self.not_running_vms
+            self.user_vms += self.not_found_vmnames
+        else:
+            for user_vm in self.user_vms.copy():
+                for vm_name in self.all_vms.keys():
+                    for vm_id in self.all_vms[vm_name]['id']:
+                        if user_vm == vm_name:
+                            self.user_vms += [vm_id]
+                            break
+                        elif user_vm == vm_id:
+                            self.user_vms += [vm_name]
+                            break
+                        else:
+                            pass
         if self.user_hosts == []:
             for k in self.all_hosts.keys():
                 self.user_hosts += [k]
                 for i in self.all_hosts[k]['id']:
                     self.user_hosts += [i]
-        self.user_hosts += self.not_found_hostnames
+            self.user_hosts += self.not_found_hostnames
+        else:
+            for user_host in self.user_hosts.copy():
+                for host_name in self.all_hosts.keys():
+                    for host_id in self.all_hosts[host_name]['id']:
+                        if user_host == host_name:
+                            self.user_hosts += [host_id]
+                        elif user_host == host_id:
+                            self.user_hosts += [host_name]
+                        else:
+                            pass
         self.user_vms = list(set(self.user_vms))
         self.user_hosts = list(set(self.user_hosts))
+        names = list(vm_timeline.keys())
+        for vm_name in names:
+            if vm_name not in self.user_vms:
+                vm_timeline.pop(vm_name)
+                continue
+            names2 = list(vm_timeline[vm_name].keys())
+            for host_name in names2:
+                if host_name not in self.user_hosts:
+                    vm_timeline[vm_name].pop(host_name)
+        self.vm_timeline = vm_timeline
 
     def find_vm_tasks(self):
+        self.needed_lines = set()
+        self.reasons = {}
         engine_formats = [fmt['regexp'] for fmt in self.formats_templates if
                           'engine' in fmt['name']]
         libvirtd_formats = [fmt['regexp'] for fmt in self.formats_templates if
@@ -144,22 +190,26 @@ class LogAnalyzer:
         for idx, log in enumerate(self.found_logs):
             if 'engine' in log.lower():
                 tasks_file, long_tasks_file, self.stuctured_commands[log], \
-                    subtasks = find_vm_tasks_engine(self.positions[log],
+                    subtasks, cur_needed_lines, cur_reasons = \
+                               find_vm_tasks_engine(self.positions[log],
                                                     self.out_descr,
                                                     self.directory,
                                                     log,
                                                     engine_formats,
                                                     self.time_zones[idx],
                                                     self.time_ranges,
-                                                    self.user_vms,
-                                                    self.user_hosts,
-                                                    self.additive_link,
-                                                    self.output_dir)
-                self.vm_tasks.update(tasks_file)
-                self.long_tasks.update(long_tasks_file)
+                                                    self.output_dir,
+                                                    self.needed_lines,
+                                                    self.reasons,
+                                                    self.criterias)
+                self.vm_tasks[log] = tasks_file
+                self.long_tasks[log] = long_tasks_file
                 self.subtasks.update(subtasks)
+                self.needed_lines = self.needed_lines.union(cur_needed_lines)
+                self.reasons.update(cur_reasons)
             elif 'libvirt' in log.lower():
-                tasks_file, long_tasks_file = \
+                tasks_file, long_tasks_file, cur_needed_lines, \
+                cur_reasons = \
                     find_vm_tasks_libvirtd(self.positions[log],
                                            self.out_descr,
                                            self.directory,
@@ -167,12 +217,14 @@ class LogAnalyzer:
                                            libvirtd_formats,
                                            self.time_zones[idx],
                                            self.time_ranges,
-                                           self.user_vms,
-                                           self.user_hosts,
-                                           self.additive_link,
-                                           self.output_dir)
-                self.vm_tasks.update(tasks_file)
-                self.long_tasks.update(long_tasks_file)
+                                           self.output_dir,
+                                           self.needed_lines,
+                                           self.reasons,
+                                           self.criterias)
+                self.vm_tasks[log] = tasks_file
+                self.long_tasks[log] = long_tasks_file
+                self.needed_lines = self.needed_lines.union(cur_needed_lines)
+                self.reasons.update(cur_reasons)
 
     def load_data(self, show_warnings, show_progressbar):
         self.all_errors = {}
@@ -194,13 +246,15 @@ class LogAnalyzer:
                                      self.user_hosts,
                                      self.time_ranges,
                                      self.user_vms,
-                                     list(self.vm_tasks.keys()) +
-                                     list(self.long_tasks.keys()) +
-                                     list(self.subtasks.keys()),
-                                     [mes['flow_id'] for t in
-                                      self.vm_tasks.keys() for mes in
-                                      (self.vm_tasks)[t] if ('flow_id'
-                                      in mes.keys() and mes['flow_id'] != '')],
+                                     self.vm_timeline,
+                                     self.subtasks,
+                                     self.needed_lines,
+                                     [mes['flow_id']
+                                      for l in self.vm_tasks.keys()
+                                      for t in self.vm_tasks[l].keys()
+                                      for mes in (self.vm_tasks)[l][t]
+                                      if ('flow_id' in mes.keys()
+                                          and mes['flow_id'] != '')],
                                      show_warnings])
                                    for i in idxs], processes=4)
         else:
@@ -216,11 +270,12 @@ class LogAnalyzer:
                          self.user_hosts,
                          self.time_ranges,
                          self.user_vms,
-                         list(self.vm_tasks.keys()) +
-                         list(self.long_tasks.keys()) +
-                         list(self.subtasks.keys()),
-                         [mes['flow_id'] for t in self.vm_tasks.keys()
-                          for mes in (self.vm_tasks)[t] if ('flow_id'
+                         self.vm_timeline,
+                         self.subtasks,
+                         self.needed_lines,
+                         [mes['flow_id'] for l in self.vm_tasks.keys()
+                          for t in self.vm_tasks[l].keys()
+                          for mes in (self.vm_tasks)[l][t] if ('flow_id'
                           in mes.keys() and mes['flow_id'] != '')],
                          show_warnings] for i in idxs]
             widget_style = ['Load: ', progressbar.Percentage(), ' (',
@@ -253,19 +308,14 @@ class LogAnalyzer:
             pass
 
     def find_important_events(self):
-        # f = open('debug_'+self.directory.split('/')[-2]+'.txt', 'w')
-        # for msg in self.merged_errors:
-        #     for field in msg:
-        #         f.write(str(field) + '   ')
-        #     f.write('\n')
-        # f.close()
         important_events, new_fields = \
             clusterize_messages(self.out_descr, self.merged_errors,
                                 self.all_fields, self.user_events,
                                 self.user_vms, self.user_hosts, self.subtasks,
                                 self.directory, self.timeline, self.vm_tasks,
-                                self.long_tasks, self.all_vms,
-                                self.all_hosts, self.output_dir)
+                                self.long_tasks, self.output_dir,
+                                self.reasons, self.needed_lines,
+                                self.criterias, self.vm_timeline)
         return important_events, new_fields
 
     def print_errors(self, errors_list, new_fields, out):
@@ -279,8 +329,9 @@ def star(input):
 
 
 def process_files(idx, log, formats_templates, directory, time_zones,
-                  positions, out_descr, user_events, user_hosts, time_ranges,
-                  user_vms, tasks, flow_ids, show_warnings, progressbar=None,
+                  positions, out_descr, additive, user_events, user_hosts,
+                  time_ranges, user_vms, vm_timeline, tasks,
+                  needed_lines, flow_ids, show_warnings, progressbar=None,
                   text_header=None):
     if text_header:
         text_header.update_mapping(type_op="Parsing:")
@@ -291,16 +342,15 @@ def process_files(idx, log, formats_templates, directory, time_zones,
                                                time_zones[idx],
                                                positions[log[idx]],
                                                out_descr,
+                                               additive,
                                                user_events,
                                                user_hosts,
                                                time_ranges,
                                                user_vms,
+                                               vm_timeline,
                                                tasks,
+                                               needed_lines,
                                                flow_ids,
                                                show_warnings,
                                                progressbar)
     return lines_info, fields_names
-
-    # def dump_to_json(self, path, outfile,
-    #                 template='chart_errors_statistics_template.html'):
-    #    pass

--- a/src/lib/LogAnalyzer.py
+++ b/src/lib/LogAnalyzer.py
@@ -39,7 +39,7 @@ class LogAnalyzer:
         self.user_hosts = user_hosts
         self.additive_link = additive_link
         if len(criterias) == 1 and criterias[0] == 'All':
-            self.criterias = ['VM id', 'Host id', 'Event', 'Subtasks',
+            self.criterias = ['Subtasks',
                               'Error or warning',
                               'Differ by VM ID', 'Exclude frequent messages',
                               'Coverage', 'Increased errors',
@@ -119,6 +119,7 @@ class LogAnalyzer:
             self.time_ranges = [[min_time, max_time]]
 
     def find_vms_and_hosts(self):
+        # if os.isdir(os.path.join(self.directory, 'log_analyzer_cache'))
         self.all_vms, self.all_hosts, self.not_running_vms, \
             self.not_found_vmnames, self.not_found_hostnames, \
             self.positions, vm_timeline = find_all_vm_host(self.positions,
@@ -310,7 +311,7 @@ class LogAnalyzer:
         important_events, new_fields = \
             clusterize_messages(self.out_descr, self.merged_errors,
                                 self.all_fields, self.user_events,
-                                self.user_vms, self.user_hosts, self.subtasks,
+                                self.all_vms, self.all_hosts, self.subtasks,
                                 self.directory, self.timeline, self.vm_tasks,
                                 self.long_tasks, self.output_dir,
                                 self.reasons, self.needed_lines,

--- a/src/lib/LogAnalyzer.py
+++ b/src/lib/LogAnalyzer.py
@@ -120,14 +120,14 @@ class LogAnalyzer:
 
     def find_vms_and_hosts(self):
         self.all_vms, self.all_hosts, self.not_running_vms, \
-        self.not_found_vmnames, self.not_found_hostnames, \
-        self.positions, vm_timeline =  find_all_vm_host(self.positions,
-                                                        self.out_descr,
-                                                        self.output_dir,
-                                                        self.directory,
-                                                        self.found_logs,
-                                                        self.time_zones,
-                                                        self.time_ranges)
+            self.not_found_vmnames, self.not_found_hostnames, \
+            self.positions, vm_timeline = find_all_vm_host(self.positions,
+                                                           self.out_descr,
+                                                           self.output_dir,
+                                                           self.directory,
+                                                           self.found_logs,
+                                                           self.time_zones,
+                                                           self.time_ranges)
         if self.user_vms == []:
             for k in self.all_vms.keys():
                 self.user_vms += [k]
@@ -190,18 +190,18 @@ class LogAnalyzer:
         for idx, log in enumerate(self.found_logs):
             if 'engine' in log.lower():
                 tasks_file, long_tasks_file, self.stuctured_commands[log], \
-                    subtasks, cur_needed_lines, cur_reasons = \
-                               find_vm_tasks_engine(self.positions[log],
-                                                    self.out_descr,
-                                                    self.directory,
-                                                    log,
-                                                    engine_formats,
-                                                    self.time_zones[idx],
-                                                    self.time_ranges,
-                                                    self.output_dir,
-                                                    self.needed_lines,
-                                                    self.reasons,
-                                                    self.criterias)
+                    subtasks, cur_needed_lines, \
+                    cur_reasons = find_vm_tasks_engine(self.positions[log],
+                                                       self.out_descr,
+                                                       self.directory,
+                                                       log,
+                                                       engine_formats,
+                                                       self.time_zones[idx],
+                                                       self.time_ranges,
+                                                       self.output_dir,
+                                                       self.needed_lines,
+                                                       self.reasons,
+                                                       self.criterias)
                 self.vm_tasks[log] = tasks_file
                 self.long_tasks[log] = long_tasks_file
                 self.subtasks.update(subtasks)
@@ -209,18 +209,17 @@ class LogAnalyzer:
                 self.reasons.update(cur_reasons)
             elif 'libvirt' in log.lower():
                 tasks_file, long_tasks_file, cur_needed_lines, \
-                cur_reasons = \
-                    find_vm_tasks_libvirtd(self.positions[log],
-                                           self.out_descr,
-                                           self.directory,
-                                           log,
-                                           libvirtd_formats,
-                                           self.time_zones[idx],
-                                           self.time_ranges,
-                                           self.output_dir,
-                                           self.needed_lines,
-                                           self.reasons,
-                                           self.criterias)
+                    cur_reasons = find_vm_tasks_libvirtd(self.positions[log],
+                                                         self.out_descr,
+                                                         self.directory,
+                                                         log,
+                                                         libvirtd_formats,
+                                                         self.time_zones[idx],
+                                                         self.time_ranges,
+                                                         self.output_dir,
+                                                         self.needed_lines,
+                                                         self.reasons,
+                                                         self.criterias)
                 self.vm_tasks[log] = tasks_file
                 self.long_tasks[log] = long_tasks_file
                 self.needed_lines = self.needed_lines.union(cur_needed_lines)

--- a/src/lib/create_error_definition.py
+++ b/src/lib/create_error_definition.py
@@ -92,6 +92,7 @@ class LogLine:
         elif not any([sign in time_part for sign in ['+', '-']]):
             # if we have time without time zone
             dt += time_zone
+        self.fields['date_time'] = ''
         for dt_format in self.dt_formats:
             try:
                 date_time = datetime.strptime(dt, dt_format)
@@ -132,16 +133,24 @@ class LogLine:
         self.fields["message"] = self.re_punctuation.sub('', mstext)
 
 
-def check_constraints(line, events, host_ids, vm_numbers, tasks, flow_ids):
+def check_constraints(line, events, host_ids, vm_numbers, additive, tasks,
+                      flow_ids):
     if any([re.search(r'(^|[ \:\.\,]+)' + keyword + r'([ \:\.\,=]+|$)',
-            line.lower()) is not None for keyword in events + host_ids +
-            vm_numbers + ['error', 'fail', 'failure', 'failed', 'traceback',
-                          'warn', 'warning', 'exception', 'down',
-                          'crash']]):
+            line.lower()) is not None for keyword in events +
+            ['error', 'fail', 'failure', 'failed', 'traceback', 'warn',
+             'warning', 'exception', 'down', 'crash']]):
         return True
     if any([thread in line for thread in tasks]):
         return True
     if any(['flow_id='+flow in line for flow in flow_ids]):
+        return True
+    if additive:
+        condition = (any([vm in line for vm in vm_numbers]) \
+                     or any([host in line for host in host_ids]))
+    else:
+        condition = (any([vm in line for vm in vm_numbers]) \
+                     and any([host in line for host in host_ids]))
+    if condition:
         return True
     else:
         return False
@@ -149,7 +158,7 @@ def check_constraints(line, events, host_ids, vm_numbers, tasks, flow_ids):
 
 def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
                      multiline_line, fields_names, out_descr, time_zone,
-                     events, host_ids, vm_numbers,
+                     additive, events, host_ids, vm_numbers,
                      format_template, prev_fields, prev_line, tasks, flow_ids,
                      show_warnings):
     # write a concatenated string that include a Traceback message (try to
@@ -160,7 +169,7 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
         prev_line = prev_line + in_traceback_line
         # check if the line satisfy user conditions
         if not check_constraints(prev_line, events, host_ids, vm_numbers,
-                                 tasks, flow_ids):
+                                 additive, tasks, flow_ids):
             return prev_line, [], in_traceback_flag, multiline_flag
         try:
             # try to match with the log file format template
@@ -197,7 +206,7 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
         prev_line = multiline_line
         # check if the line satisfy user conditions
         if not check_constraints(prev_line, events, host_ids, vm_numbers,
-                                 tasks, flow_ids):
+                                 additive, tasks, flow_ids):
             return prev_line, [], in_traceback_flag, multiline_flag
         try:
             # try to match with the log file format template
@@ -246,7 +255,7 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
     else:
         # check if the line satisfy user conditions
         if not check_constraints(prev_line, events, host_ids, vm_numbers,
-                                 tasks, flow_ids):
+                                 additive, tasks, flow_ids):
             return prev_line, [], in_traceback_flag, multiline_flag
         line_info = []
         for field in fields_names:
@@ -255,8 +264,9 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
 
 
 def loop_over_lines(directory, logname, format_template, time_zone, positions,
-                    out_descr, events, host_ids, time_ranges, vm_numbers,
-                    tasks, flow_ids, show_warnings, progressbar=None):
+                    out_descr, additive, events, host_ids,
+                    time_ranges, vm_numbers, tasks, flow_ids, show_warnings,
+                    progressbar=None):
     full_filename = os.path.join(directory, logname)
     # format_template = re.compile(format_template)
     fields_names = list(sorted(format_template.groupindex.keys()))
@@ -307,6 +317,7 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                                                           fields_names,
                                                           out_descr,
                                                           time_zone,
+                                                          additive,
                                                           events, host_ids,
                                                           vm_numbers,
                                                           format_template,
@@ -331,8 +342,8 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                         create_line_info(in_traceback_flag,
                                          in_traceback_line, multiline_flag,
                                          multiline_line, fields_names,
-                                         out_descr, time_zone, events,
-                                         host_ids, vm_numbers,
+                                         out_descr, time_zone, additive, 
+                                         events, host_ids, vm_numbers,
                                          format_template, prev_fields,
                                          prev_line, tasks, flow_ids,
                                          show_warnings)
@@ -392,8 +403,8 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                         create_line_info(in_traceback_flag,
                                          in_traceback_line, multiline_flag,
                                          multiline_line, fields_names,
-                                         out_descr, time_zone, events,
-                                         host_ids, vm_numbers,
+                                         out_descr, time_zone, additive,
+                                         events, host_ids, vm_numbers,
                                          format_template, prev_fields,
                                          prev_line, tasks, flow_ids,
                                          show_warnings)
@@ -418,7 +429,7 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                 create_line_info(in_traceback_flag,
                                  in_traceback_line, multiline_flag,
                                  multiline_line, fields_names, out_descr,
-                                 time_zone, events, host_ids,
+                                 time_zone, additive, events, host_ids,
                                  vm_numbers, format_template, prev_fields,
                                  prev_line, tasks, flow_ids, show_warnings)
             if line_info != []:

--- a/src/lib/create_error_definition.py
+++ b/src/lib/create_error_definition.py
@@ -133,14 +133,16 @@ class LogLine:
         self.fields["message"] = self.re_punctuation.sub('', mstext)
 
 
-def check_constraints(line, events, host_ids, vm_numbers, additive, tasks,
-                      flow_ids):
+def check_constraints(line, events, host_ids, vm_numbers, additive, dt,
+                      task_lines, line_num, flow_ids, subtasks, vm_timeline):
     if any([re.search(r'(^|[ \:\.\,]+)' + keyword + r'([ \:\.\,=]+|$)',
             line.lower()) is not None for keyword in events +
             ['error', 'fail', 'failure', 'failed', 'traceback', 'warn',
              'warning', 'exception', 'down', 'crash']]):
         return True
-    if any([thread in line for thread in tasks]):
+    if (line_num in task_lines):
+        return True
+    if any([task_id in line for task_id in subtasks.keys()]):
         return True
     if any(['flow_id='+flow in line for flow in flow_ids]):
         return True
@@ -148,19 +150,28 @@ def check_constraints(line, events, host_ids, vm_numbers, additive, tasks,
         condition = (any([vm in line for vm in vm_numbers]) \
                      or any([host in line for host in host_ids]))
     else:
-        condition = (any([vm in line for vm in vm_numbers]) \
-                     and any([host in line for host in host_ids]))
-    if condition:
-        return True
-    else:
-        return False
+        condition = check_vm_on_host(dt, line, host_ids, vm_numbers, additive,
+                                     vm_timeline)
+    return  condition
 
+
+def check_vm_on_host(dt, line, host_ids, vm_numbers, additive, vm_timeline):
+    for vm_name in vm_timeline.keys():
+        if vm_name not in line:
+            continue
+        for host_name in vm_timeline[vm_name].keys():
+            if host_name in line:
+                return True
+            if any([dt >= tr[0] and dt <= tr[1]
+                    for tr in vm_timeline[vm_name][host_name]]):
+                return True
+    return False
 
 def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
                      multiline_line, fields_names, out_descr, time_zone,
-                     additive, events, host_ids, vm_numbers,
-                     format_template, prev_fields, prev_line, tasks, flow_ids,
-                     show_warnings):
+                     additive, subtasks, events, host_ids, vm_numbers,
+                     vm_timeline, format_template, prev_fields, prev_line,
+                     task_lines, flow_ids, show_warnings):
     # write a concatenated string that include a Traceback message (try to
     # match the template first (if there were any fields that appear in the
     # other lines)
@@ -169,7 +180,9 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
         prev_line = prev_line + in_traceback_line
         # check if the line satisfy user conditions
         if not check_constraints(prev_line, events, host_ids, vm_numbers,
-                                 additive, tasks, flow_ids):
+                                 additive, prev_fields['date_time'], task_lines,
+                                 prev_fields['line_num'],
+                                 flow_ids, subtasks, vm_timeline):
             return prev_line, [], in_traceback_flag, multiline_flag
         try:
             # try to match with the log file format template
@@ -184,7 +197,6 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
                     line_info += [mess.fields["message"]]
                     continue
                 line_info += [prev_fields[field]]
-            # line_info += [mess.fields["message"]]
             if show_warnings:
                 out_descr.put('Info: create_line_info: ' +
                               'Traceback matched: %s\n' %
@@ -206,7 +218,9 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
         prev_line = multiline_line
         # check if the line satisfy user conditions
         if not check_constraints(prev_line, events, host_ids, vm_numbers,
-                                 additive, tasks, flow_ids):
+                                 additive, prev_fields['date_time'],
+                                 task_lines, prev_fields['line_num'],
+                                 flow_ids, subtasks, vm_timeline):
             return prev_line, [], in_traceback_flag, multiline_flag
         try:
             # try to match with the log file format template
@@ -220,7 +234,6 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
             line_info = []
             for field in fields_names:
                 line_info += [mess.fields[field]]
-            # line_info += [mess.fields["message"]]
             if show_warnings:
                 out_descr.put('Info: create_line_info: ' +
                               'Multiline matched: %s\n' %
@@ -255,7 +268,9 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
     else:
         # check if the line satisfy user conditions
         if not check_constraints(prev_line, events, host_ids, vm_numbers,
-                                 additive, tasks, flow_ids):
+                                 additive, prev_fields['date_time'], task_lines,
+                                 prev_fields['line_num'],
+                                 flow_ids, subtasks, vm_timeline):
             return prev_line, [], in_traceback_flag, multiline_flag
         line_info = []
         for field in fields_names:
@@ -265,10 +280,9 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
 
 def loop_over_lines(directory, logname, format_template, time_zone, positions,
                     out_descr, additive, events, host_ids,
-                    time_ranges, vm_numbers, tasks, flow_ids, show_warnings,
-                    progressbar=None):
+                    time_ranges, vm_numbers, vm_timeline, subtasks, task_lines,
+                    flow_ids, show_warnings, progressbar=None):
     full_filename = os.path.join(directory, logname)
-    # format_template = re.compile(format_template)
     fields_names = list(sorted(format_template.groupindex.keys()))
     fields_names.remove("message")
     fields_names.remove("date_time")
@@ -318,11 +332,14 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                                                           out_descr,
                                                           time_zone,
                                                           additive,
+                                                          subtasks,
                                                           events, host_ids,
                                                           vm_numbers,
+                                                          vm_timeline,
                                                           format_template,
                                                           prev_fields,
-                                                          prev_line, tasks,
+                                                          prev_line,
+                                                          task_lines,
                                                           flow_ids,
                                                           show_warnings)
                     # if we normally parsed the previous line, we save it
@@ -343,10 +360,11 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                                          in_traceback_line, multiline_flag,
                                          multiline_line, fields_names,
                                          out_descr, time_zone, additive, 
-                                         events, host_ids, vm_numbers,
-                                         format_template, prev_fields,
-                                         prev_line, tasks, flow_ids,
-                                         show_warnings)
+                                         subtasks, events, host_ids,
+                                         vm_numbers, vm_timeline,
+                                         format_template,
+                                         prev_fields, prev_line, task_lines,
+                                         flow_ids,show_warnings)
                     # if we normally parsed the previous line, we save it
                     if line_info != []:
                         file_lines += [line_info]
@@ -404,10 +422,11 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                                          in_traceback_line, multiline_flag,
                                          multiline_line, fields_names,
                                          out_descr, time_zone, additive,
-                                         events, host_ids, vm_numbers,
-                                         format_template, prev_fields,
-                                         prev_line, tasks, flow_ids,
-                                         show_warnings)
+                                         subtasks, events, host_ids,
+                                         vm_numbers, vm_timeline,
+                                         format_template,
+                                         prev_fields, prev_line, task_lines,
+                                         flow_ids, show_warnings)
                     if line_info != []:
                         file_lines += [line_info]
                 multiline_flag = True
@@ -429,12 +448,14 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                 create_line_info(in_traceback_flag,
                                  in_traceback_line, multiline_flag,
                                  multiline_line, fields_names, out_descr,
-                                 time_zone, additive, events, host_ids,
-                                 vm_numbers, format_template, prev_fields,
-                                 prev_line, tasks, flow_ids, show_warnings)
+                                 time_zone, additive, subtasks, events,
+                                 host_ids, vm_numbers, vm_timeline,
+                                 format_template,
+                                 prev_fields, prev_line, task_lines,
+                                 flow_ids, show_warnings)
             if line_info != []:
                 file_lines += [line_info]
     f.close()
     if progressbar:
         progressbar.finish()
-    return file_lines, fields_names  # + ['message']
+    return file_lines, fields_names

--- a/src/lib/create_error_definition.py
+++ b/src/lib/create_error_definition.py
@@ -147,12 +147,12 @@ def check_constraints(line, events, host_ids, vm_numbers, additive, dt,
     if any(['flow_id='+flow in line for flow in flow_ids]):
         return True
     if additive:
-        condition = (any([vm in line for vm in vm_numbers]) \
+        condition = (any([vm in line for vm in vm_numbers])
                      or any([host in line for host in host_ids]))
     else:
         condition = check_vm_on_host(dt, line, host_ids, vm_numbers, additive,
                                      vm_timeline)
-    return  condition
+    return condition
 
 
 def check_vm_on_host(dt, line, host_ids, vm_numbers, additive, vm_timeline):
@@ -167,6 +167,7 @@ def check_vm_on_host(dt, line, host_ids, vm_numbers, additive, vm_timeline):
                 return True
     return False
 
+
 def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
                      multiline_line, fields_names, out_descr, time_zone,
                      additive, subtasks, events, host_ids, vm_numbers,
@@ -180,8 +181,8 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
         prev_line = prev_line + in_traceback_line
         # check if the line satisfy user conditions
         if not check_constraints(prev_line, events, host_ids, vm_numbers,
-                                 additive, prev_fields['date_time'], task_lines,
-                                 prev_fields['line_num'],
+                                 additive, prev_fields['date_time'],
+                                 task_lines, prev_fields['line_num'],
                                  flow_ids, subtasks, vm_timeline):
             return prev_line, [], in_traceback_flag, multiline_flag
         try:
@@ -268,8 +269,8 @@ def create_line_info(in_traceback_flag, in_traceback_line, multiline_flag,
     else:
         # check if the line satisfy user conditions
         if not check_constraints(prev_line, events, host_ids, vm_numbers,
-                                 additive, prev_fields['date_time'], task_lines,
-                                 prev_fields['line_num'],
+                                 additive, prev_fields['date_time'],
+                                 task_lines, prev_fields['line_num'],
                                  flow_ids, subtasks, vm_timeline):
             return prev_line, [], in_traceback_flag, multiline_flag
         line_info = []
@@ -359,12 +360,12 @@ def loop_over_lines(directory, logname, format_template, time_zone, positions,
                         create_line_info(in_traceback_flag,
                                          in_traceback_line, multiline_flag,
                                          multiline_line, fields_names,
-                                         out_descr, time_zone, additive, 
+                                         out_descr, time_zone, additive,
                                          subtasks, events, host_ids,
                                          vm_numbers, vm_timeline,
                                          format_template,
                                          prev_fields, prev_line, task_lines,
-                                         flow_ids,show_warnings)
+                                         flow_ids, show_warnings)
                     # if we normally parsed the previous line, we save it
                     if line_info != []:
                         file_lines += [line_info]

--- a/src/lib/detect_running_components.py
+++ b/src/lib/detect_running_components.py
@@ -1,7 +1,7 @@
 import os
 import re
 import lzma
-# import json
+import json
 import pytz
 import numpy as np
 from datetime import datetime
@@ -29,6 +29,7 @@ def parse_date_time(line, time_zone):
     elif not any([sign in time_part for sign in ['+', '-']]):
         # if we have time without time zone
         dt += time_zone
+    date_time = ''
     for dt_format in dt_formats:
         try:
             date_time = datetime.strptime(dt, dt_format)
@@ -179,7 +180,7 @@ def find_needed_linenum(output_descriptor, log_directory, files, tz_info,
     return needed_linenum
 
 
-def libvirtd_vm_host(f, filename, pos, tz_info, vm_names, host_names,
+def libvirtd_vm_host(f, filename, pos, tz_info, vms, hosts,
                      time_range_info):
     cur = {}
     multiline = False
@@ -213,27 +214,24 @@ def libvirtd_vm_host(f, filename, pos, tz_info, vm_names, host_names,
         host_id = re.search(r'\<hostuuid\>(.+?)\<\/hostuuid\>', line)
         if (multiline and host_id is not None):
             cur['host_id'] = host_id.group(1)
-            if (cur['vm_name'] not in vm_names.keys()):
-                vm_names[cur['vm_name']] = set()
-            if ('<id_not_found>' in vm_names[cur['vm_name']]):
-                vm_names[cur['vm_name']].remove('<id_not_found>')
-            vm_names[cur['vm_name']].add(cur['vm_id'])
-            if (cur['host_name'] not in host_names.keys()):
-                host_names[cur['host_name']] = set()
-            if ('<id_not_found>' in host_names[cur['host_name']]):
-                host_names[cur['host_name']].remove('<id_not_found>')
-            host_names[cur['host_name']].add(cur['host_id'])
+            if (cur['vm_name'] not in vms.keys()):
+                vms[cur['vm_name']] = {'id': set(), 'hostids': set()}
+            vms[cur['vm_name']]['id'].add(cur['vm_id'])
+            vms[cur['vm_name']]['hostids'].add(cur['host_id'])
+            if (cur['host_name'] not in hosts.keys()):
+                hosts[cur['host_name']] = {'id': set(), 'vmids': set()}
+            hosts[cur['host_name']]['id'].add(cur['host_id'])
+            hosts[cur['host_name']]['vmids'].add(cur['vm_id'])
             multiline = False
             cur = {}
             continue
         if multiline:
+            # host was not found
             if (cur != {} and 'vm_name' in cur.keys() and
                     'vm_id' in cur.keys()):
-                if (cur['vm_name'] not in vm_names.keys()):
-                    vm_names[cur['vm_name']] = set()
-                if ('<id_not_found>' in vm_names[cur['vm_name']]):
-                    vm_names[cur['vm_name']].remove('<id_not_found>')
-                vm_names[cur['vm_name']].add(cur['vm_id'])
+                if (cur['vm_name'] not in vms.keys()):
+                    vms[cur['vm_name']] = {'id': set(), 'hostids': set()}
+                vms[cur['vm_name']]['id'].add(cur['vm_name'])
             multiline = False
             cur = {}
             continue
@@ -242,37 +240,17 @@ def libvirtd_vm_host(f, filename, pos, tz_info, vm_names, host_names,
         if other_vm is None:
             other_vm = re.search(r'vm=(.+?), uuid=(.+?)\,', line)
         if other_vm is not None:
-            if (other_vm.group(1) not in vm_names.keys()):
-                vm_names[other_vm.group(1)] = set()
-            if ('<id_not_found>' in vm_names[other_vm.group(1)]):
-                vm_names[other_vm.group(1)].remove('<id_not_found>')
-            vm_names[other_vm.group(1)].add(other_vm.group(2))
-            continue
-        if 'vdsm' in filename.lower():
-            vdsm_vm = re.search(
-                r'vmId=\'(.+?)\'.+\'vmName\':\ *[u]*\'(.+?)\'', line)
-            if vdsm_vm is not None:
-                if (vdsm_vm.group(2) not in vm_names.keys()):
-                    vm_names[vdsm_vm.group(2)] = set()
-                if ('<id_not_found>' in vm_names[vdsm_vm.group(2)]):
-                    vm_names[vdsm_vm.group(2)].remove('<id_not_found>')
-                vm_names[vdsm_vm.group(2)].add(vdsm_vm.group(1))
-                continue
-            vdsm_host = re.search(r'I am the actual vdsm ' +
-                                  r'([^\ ]+)\ +([^\ ]+)', line)
-            if vdsm_host is None:
-                continue
-            if (vdsm_host.group(2) not in host_names.keys()):
-                host_names[vdsm_host.group(2)] = set(
-                                                    ['<id_not_found>'])
-            else:
-                if (len(host_names[vdsm_host.group(2)]) == 0):
-                    host_names[vdsm_host.group(2)].add(
-                                                    '<id_not_found>')
-    return vm_names, host_names, real_firstpos
+            if (other_vm.group(1) not in vms.keys()):
+                vms[other_vm.group(1)] = {'id': set(), 'hostids': set()}
+            vms[other_vm.group(1)]['id'].add(other_vm.group(2))
+    return vms, hosts, real_firstpos
 
 
-def engine_vm_host(f, pos, tz_info, vm_names, host_names, time_range_info):
+def vdsm_vm_host(f, filename, pos, tz_info, vms, hosts,
+                     time_range_info):
+    cur = {}
+    this_host = ''
+    multiline = False
     f.seek(pos, os.SEEK_SET)
     dt = 0
     while dt < time_range_info[0]:
@@ -287,104 +265,129 @@ def engine_vm_host(f, pos, tz_info, vm_names, host_names, time_range_info):
             continue
         # if dt > time_range_info[1]:
         #     break
+        vdsm_host = re.search(r'I am the actual vdsm ' +
+                              r'([^\ ]+)\ +([^\ ]+)', line)
+        if vdsm_host is not None:
+            this_host = vdsm_host.group(2)
+            if (this_host not in hosts.keys()):
+                hosts[this_host] = {'id': set(), 'vmids': set()}        
+        vm_name = re.search(r'\<name\>(.+?)\<\/name\>', line)
+        if (not multiline and vm_name is not None):
+            multiline = True
+            cur['vm_name'] = vm_name.group(1)
+            continue
+        vm_id = re.search(r'\<uuid\>(.+?)\<\/uuid\>', line)
+        if (multiline and vm_id is not None):
+            cur['vm_id'] = vm_id.group(1)
+            if (cur['vm_name'] not in vms.keys()):
+                vms[cur['vm_name']] = {'id': set(), 'hostids': set()}
+            vms[cur['vm_name']]['id'].add(cur['vm_id'])
+            if this_host != '':
+                vms[cur['vm_name']]['hostids'].add(this_host)
+                hosts[this_host]['vmids'].add(cur['vm_id'])
+            multiline = False
+            cur = {}
+            continue
+        other_vm = re.search(
+            r'vmId=\'(.+?)\'.+\'vmName\':\ *[u]*\'(.+?)\'', line)
+        if other_vm is not None:
+            if (other_vm.group(2) not in vms.keys()):
+                vms[other_vm.group(2)] = {'id': set(), 'hostids': set()}
+            vms[other_vm.group(2)]['id'].add(other_vm.group(1))
+            if this_host != '':
+                vms[other_vm.group(2)]['hostids'].add(this_host)
+                hosts[this_host]['vmids'].add(other_vm.group(1))
+    return vms, hosts, real_firstpos
+
+def engine_vm_host(f, pos, tz_info, vms, hosts, time_range_info):
+    f.seek(pos, os.SEEK_SET)
+    dt = 0
+    while dt < time_range_info[0]:
+        dt = 0
+        while dt == 0:
+            real_firstpos = f.tell()
+            dt = parse_date_time(f.readline(), tz_info)
+    f.seek(real_firstpos, os.SEEK_SET)
+    for line_num, line in enumerate(f):
+        dt = parse_date_time(line, tz_info)
+        if dt == 0:
+            continue
+        vm_name = ''
+        vm_id = ''
+        host_name = ''
+        host_id = ''
+        # if dt > time_range_info[1]:
+        #     break
         if any([v in line.lower() for v in ['vmid', 'vmname', 'vm_name']]):
             if (re.search(r"vmId=\'(.+?)\'", line) is not None):
-                res_id = re.search(r"vmId=\'(.+?)\'", line).group(1)
+                vm_id = re.search(r"vmId=\'(.+?)\'", line).group(1)
             elif (re.search(r"\'vmId\'\ *[:=]\ *u*\'(.+?)\'",
                             line) is not None):
-                res_id = re.search(
+                vm_id = re.search(
                     r"\'vmId\'\ *[:=]\ *u*\'(.+?)\'", line).group(1)
             else:
-                res_id = '<id_not_found>'
+                vm_id = ''
             if (re.search(r"vmName\ *=\ *(.+?),", line) is not None):
-                res_name = re.sub('[\'\"]', '',
+                vm_name = re.sub('[\'\"]', '',
                                   re.search(r"vmName\ *=\ *(.+?),",
                                             line).group(1))
             elif (re.search(r"vm\ *=\ *\'VM\ *\[([^\[\]]*?)\]\'",
                             line) is not None):
-                res_name = re.sub('[\'\"]', '',
+                vm_name = re.sub('[\'\"]', '',
                                   re.search(r"vm\ *=\ *\'VM\ *" +
                                             r"\[([^\[\]]*?)\]\'",
                                             line).group(1))
             elif (re.search(r"\[(.+?)=VM_NAME\]", line) is not None):
-                res_name = re.sub('[\'\"]', '',
+                vm_name = re.sub('[\'\"]', '',
                                   re.search(r"\[([^\[\]]*?)=VM_NAME\]",
                                             line).group(1))
             elif (re.search(r"\[(.+?)=VM\]", line) is not None):
-                res_name = re.sub('[\'\"]', '',
+                vm_name = re.sub('[\'\"]', '',
                                   re.search(r"\[([^\[\]]*?)=VM\]",
                                             line).group(1))
             elif (re.search(r"\'vmName\'\ *[:=]\ *u*\'([^\']*?)\'",
                             line) is not None):
-                res_name = re.sub('[\'\"]', '',
+                vm_name = re.sub('[\'\"]', '',
                                   re.search(r"\'vmName\'" +
                                             r"\ *[:=]\ *u*\'([^\']*?)\'",
                                             line).group(1))
             else:
-                res_name = '<name_not_found>'
-            if res_name.lower() == 'null':
-                res_name = '<name_not_found>'
-            if res_id.lower() == 'null':
-                res_id = '<id_not_found>'
-            if ((res_name == '<name_not_found>' or res_name == '') and
-                    (res_id == '<id_not_found>' or res_id == '')):
-                continue
-            if res_name not in vm_names.keys():
-                vm_names[res_name] = set()
-            if res_id not in vm_names[res_name]:
-                if (len(vm_names[res_name]) > 0
-                        and res_id == '<id_not_found>'):
-                    pass
-                elif res_id != '<id_not_found>' and \
-                        '<id_not_found>' in vm_names[res_name]:
-                    vm_names[res_name].remove('<id_not_found>')
-                    vm_names[res_name].add(res_id)
-                else:
-                    vm_names[res_name].add(res_id)
-        if 'hostname' in line.lower():
-            res_name = re.search(r"HostName\ *=\ *(.+?),", line)
-            if res_name is not None:
-                res_name = res_name.group(1)
-            else:
-                res_name = '<name_not_found>'
-            res_id = re.search(r"hostId=\'(.+?)\'", line)
-            if res_id is not None:
-                res_id = res_id.group(1)
-            else:
-                res_id = '<id_not_found>'
-            if (res_name == '<name_not_found>' and
-                    (res_id == '<id_not_found>'
-                     or res_id.lower() == 'null')):
-                continue
-            if res_name not in host_names.keys():
-                host_names[res_name] = set()
-            if res_id not in host_names[res_name]:
-                if (len(host_names[res_name]) > 0
-                        and res_id == '<id_not_found>'):
-                    pass
-                elif (res_id != '<id_not_found>'
-                        and '<id_not_found>' in host_names[res_name]):
-                    host_names[res_name].remove('<id_not_found>')
-                    host_names[res_name].add(res_id)
-                else:
-                    host_names[res_name].add(res_id)
-        other_vm = re.search(r'VM\ *\'(.{30,40}?)\'\ *' +
+                vm_name = ''
+        if (vm_name == '' and vm_id == ''):
+            other_vm = re.search(r'VM\ *\'(.{30,40}?)\'\ *' +
                              r'\(([^\(\)]*?)\)', line)
-        if (other_vm is not None and other_vm.group(1).lower() != 'null'):
-            if other_vm.group(2) not in vm_names.keys():
-                vm_names[other_vm.group(2)] = set()
-            if (other_vm.group(1) not in vm_names[other_vm.group(2)]):
-                if (len(vm_names[other_vm.group(2)]) > 0
-                        and other_vm.group(1) == '<id_not_found>'):
-                    pass
-                elif (other_vm.group(1) != '<id_not_found>'
-                        and '<id_not_found>'in
-                        vm_names[other_vm.group(2)]):
-                    vm_names[other_vm.group(2)].remove('<id_not_found>')
-                    vm_names[other_vm.group(2)].add(other_vm.group(1))
-                else:
-                    vm_names[other_vm.group(2)].add(other_vm.group(1))
-    return vm_names, host_names, real_firstpos
+            if (other_vm is not None):
+                vm_name = other_vm.group(2)
+                vm_id = other_vm.group(1)
+        if (any([i in line.lower() for i in ['hostid',
+                                             'hostname']])):
+            host_name = re.search(r"HostName\ *=\ *(.+?),", line)
+            if host_name is not None:
+                host_name = host_name.group(1)
+            else:
+                host_name = ''
+            host_id = re.search(r"hostId=\'(.+?)\'", line)
+            if host_id is not None:
+                host_id = host_id.group(1)
+            else:
+                host_id = ''
+        if vm_name.lower() == 'null':
+            vm_name = ''
+        if vm_id.lower() == 'null':
+            vm_id = ''
+        if host_id.lower() == 'null':
+            host_id = ''
+        if host_name.lower() == 'null':
+            host_name = ''
+        if vm_name not in vms.keys():
+            vms[vm_name] = {'id': set(), 'hostids': set()}
+        vms[vm_name]['id'].add(vm_id)
+        vms[vm_name]['hostids'].add(host_name)
+        if host_name not in hosts.keys():
+            hosts[host_name] = {'id': set(), 'vmids': set()}
+        hosts[host_name]['id'].add(host_id)
+        hosts[host_name]['vmids'].add(vm_id)
+    return vms, hosts, real_firstpos
 
 
 def find_all_vm_host(positions,
@@ -393,8 +396,8 @@ def find_all_vm_host(positions,
                      files,
                      tz_info,
                      time_range_info):
-    vm_names = {}
-    host_names = {}
+    vms = {}
+    hosts = {}
     # list of number of first lines for the time range to pass others
     first_lines = {}
     for log_idx, log in enumerate(files):
@@ -408,29 +411,76 @@ def find_all_vm_host(positions,
             continue
         first_lines[log] = []
         for tr_idx, log_position in enumerate(positions[log]):
-            if any([f in log.lower() for f in ['libvirt', 'vdsm']]):
-                vm_names, host_names, firstline_pos = \
+            if 'vdsm' in log.lower():
+                vms, hosts, firstline_pos = \
+                    vdsm_vm_host(f, log, 0,  # log_position,
+                                     tz_info[log_idx], vms, hosts,
+                                     time_range_info[tr_idx])
+            elif 'libvirt' in log.lower():
+                vms, hosts, firstline_pos = \
                     libvirtd_vm_host(f, log, 0,  # log_position,
-                                     tz_info[log_idx], vm_names, host_names,
+                                     tz_info[log_idx], vms, hosts,
                                      time_range_info[tr_idx])
             else:
-                vm_names, host_names, firstline_pos = \
+                vms, hosts, firstline_pos = \
                     engine_vm_host(f, 0,  # log_position,
                                    tz_info[log_idx],
-                                   vm_names, host_names,
+                                   vms, hosts,
                                    time_range_info[tr_idx])
             first_lines[log] += [firstline_pos]
         f.close()
-    if '<name_not_found>' in vm_names.keys():
-        for name in vm_names.keys():
-            if name == '<name_not_found>':
-                continue
-            for uuid in vm_names[name]:
-                if uuid in vm_names['<name_not_found>']:
-                    vm_names['<name_not_found>'].remove(uuid)
-        if vm_names['<name_not_found>'] == set():
-            vm_names.pop('<name_not_found>', None)
-    return vm_names, host_names, first_lines
+    # print('------VMS------')
+    not_running_vms = []
+    for k in sorted(vms.keys()):
+        if '' in vms[k]['id']:
+            vms[k]['id'].remove('')
+        if (len(vms[k]['id']) == 0):
+            not_running_vms += [k]
+            vms.pop(k)
+    not_found_vmnames = []
+    for k in sorted(vms.keys()):
+        if ('' in vms[k]['hostids']):
+            vms[k]['hostids'].remove('')
+        if k in not_running_vms and len(vms[k]['id']) > 0:
+            not_running_vms.remove(k)
+        if k == '':
+            not_found_vmnames = list(vms[k]['id'])
+            if '' in not_found_vmnames:
+                not_found_vmnames.remove('')
+            vms.pop(k)
+            continue
+        if not_found_vmnames != []:
+            for v in not_found_vmnames.copy():
+                if v in list(vms[k]['id']):
+                    not_found_vmnames.remove(v)
+        # print(k,':id:',[j for j in vms[k]['id']],'\n',k,':found on hosts:',[j for j in vms[k]['hostids']])
+        # print('---')
+    # print('Not running VMs:', not_running_vms)
+    # print('Not found VM names:', not_found_vmnames)
+    # print()
+    not_found_hostnames = []
+    # print('------HOSTS------')
+    for k in sorted(hosts.keys()):
+        if k == '':
+            not_found_hostnames = list(hosts[k]['id'])
+            if '' in not_found_hostnames:
+                not_found_hostnames.remove('')
+            hosts.pop(k)
+            continue
+        if not_found_hostnames != []:
+            for i in not_found_hostnames.copy():
+                if i in list(hosts[k]['id']):
+                    not_found_hostnames.remove(i)
+        if ('' in hosts[k]['id']):
+            hosts[k]['id'].remove('')
+        if ('' in hosts[k]['vmids']):
+            hosts[k]['vmids'].remove('')
+        # print(k,':id:',[j for j in hosts[k]['id']],'\n',k,':found vms:',[j for j in hosts[k]['vmids']])
+        # print()
+    # print('Not found host names:',not_found_hostnames)
+    # exit()
+    return vms, hosts, not_running_vms, not_found_vmnames, \
+            not_found_hostnames, first_lines
 
 
 def find_vm_tasks_engine(positions,
@@ -440,10 +490,12 @@ def find_vm_tasks_engine(positions,
                          file_formats,
                          tz_info,
                          time_range_info,
-                         user_vms, user_hosts):
+                         user_vms, user_hosts, additive):
     commands_threads = {}
     long_actions = []
     needed_threads = set()
+    subtasks = []
+    subtasks_ids = []
     if (log[-4:] == '.log'):
             f = open(log)
     elif (log[-3:] == '.xz'):
@@ -474,25 +526,38 @@ def find_vm_tasks_engine(positions,
                 continue
             if (dt > time_range_info[tr_idx][1]):
                 break
-            if (any([vm in fields["message"] for vm in user_vms]) or
-                    any([host in fields["message"] for host in user_hosts])):
+            if additive:
+                condition = (any([vm in fields["message"]
+                                  for vm in user_vms]) \
+                             or any([host in fields["message"]
+                                     for host in user_hosts]))
+            else:
+                condition = (any([vm in fields["message"]
+                                  for vm in user_vms]) \
+                             and any([host in fields["message"]
+                                     for host in user_hosts]))
+            if (condition):
                 needed_threads.add(fields["thread"])
-            com = re.search(r"\((.+?)\)\ +\[(.*?)\]\ +Running command:\ +" +
-                            r"([^\s]+)Command", line)
+            com = re.search(r"\((.+?)\)\ +\[(.*?)\]\ +" +
+                            r"[Rr]unning [Cc]ommand:\ +" +
+                            r"([^\s]+)[Cc]ommand", line)
             if (com is not None):
                 if (com.group(1) not in commands_threads.keys()):
                     commands_threads[com.group(1)] = []
                 commands_threads[com.group(1)] += [
                                  {'command_name': com.group(3),
-                                  'command_start_name': com.group(3)}]
+                                  'command_start_name': com.group(3),
+                                  'subtasks': []}]
                 continue
-            start = re.search(r"\((.+?)\)\ +\[(.*?)\]\ +START,\ +" +
+            start = re.search(r"\((.+?)\)\ +\[(.*?)\]\ +" +
+                              r"[Ss][Tt][Aa][Rr][Tt],\ +" +
                               r"([^\s]+)Command.*\ +log id:\ (.+)", line)
             if (start is not None):
                 if (start.group(1) not in commands_threads.keys()):
                     commands_threads[start.group(1)] = [
                                      {'command_name': start.group(3),
                                       'command_start_name': start.group(3),
+                                      'subtasks': [],
                                       'start_time': dt,
                                       'log_id': start.group(4),
                                       'flow_id': start.group(2)}]
@@ -507,6 +572,7 @@ def find_vm_tasks_engine(positions,
                         commands_threads[start.group(1)][com_id] = \
                             {'command_name': com_name,
                              'command_start_name': start.group(3),
+                             'subtasks': [],
                              'start_time': dt,
                              'log_id': start.group(4),
                              'flow_id': start.group(2)}
@@ -514,17 +580,20 @@ def find_vm_tasks_engine(positions,
                         commands_threads[start.group(1)] += [
                                          {'command_name': start.group(3),
                                           'command_start_name': start.group(3),
+                                          'subtasks': [],
                                           'start_time': dt,
                                           'log_id': start.group(4),
                                           'flow_id': start.group(2)}]
                 continue
-            finish = re.search(r"\((.+?)\)\ +\[(.*?)\]\ +FINISH,\ +" +
+            finish = re.search(r"\((.+?)\)\ +\[(.*?)\]\ +" +
+                               r"[Ff][Ii][Nn][Ii][Ss][Hh],\ +" +
                                r"([^\s]+)Command.*\ +log id:\ (.+)", line)
             if (finish is not None):
                 if (finish.group(1) not in commands_threads.keys()):
                     commands_threads[finish.group(1)] = [
                                      {'command_name': finish.group(3),
                                       'command_start_name': finish.group(3),
+                                      'subtasks': [],
                                       'log_id': finish.group(4),
                                       'flow_id': finish.group(2)}]
                     # com_id = 0
@@ -539,13 +608,14 @@ def find_vm_tasks_engine(positions,
                         commands_threads[finish.group(1)] += [{
                                          'command_name': finish.group(3),
                                          'command_start_name': finish.group(3),
+                                         'subtasks': [],
                                          'log_id': finish.group(4),
                                          'flow_id': finish.group(2)}]
                         continue
-                for task_idx, task in \
+                for task_idx, command in \
                         enumerate(commands_threads[finish.group(1)]):
-                    if ('log_id' in task.keys() and
-                            task['log_id'] == finish.group(4)):
+                    if ('log_id' in command.keys() and
+                            command['log_id'] == finish.group(4)):
                         commands_threads[finish.group(1)][
                                                 task_idx]['finish_time'] = dt
                         if ('start_time' in commands_threads[
@@ -556,19 +626,60 @@ def find_vm_tasks_engine(positions,
                                                  task_idx]['finish_time'] - \
                                 commands_threads[finish.group(1)][
                                                  task_idx]['start_time']
+                            break
+            subtask_start = re.search(r"\((.+?)\)\ +\[.*?\].+?" +
+                                r"[Aa]dding [Tt]ask\ +\'(.+?)\'\ +" +
+                                r"\(*[Pp]arent [Cc]ommand\ +\'(.+?)\'.*\)",
+                                line)
+            if subtask_start is not None:
+                if (subtask_start.group(1) not in commands_threads.keys()):
+                    continue
+                for task_idx, command in \
+                        enumerate(commands_threads[subtask_start.group(1)]):
+                    if (command['command_name'] in subtask_start.group(3)):
+                        commands_threads[subtask_start.group(1)][
+                                task_idx]['subtasks'] += [
+                                {'id': subtask_start.group(2),
+                                 'start_time': dt}]
+                        subtasks += [{'id': subtask_start.group(2),
+                                      'parent_thread': subtask_start.group(1),
+                                      'task_idx': task_idx}]
+                        subtasks_ids += [subtask_start.group(2)]
+                        break
+            subtask_end = re.search(r"[Rr]emoved [Tt]ask\ +\'(.+?)\'\ +" +
+                                    r"[Ff]rom [Dd]ata[Bb]ase", line)
+            if subtask_end is None:
+                continue
+            for subtask_idx, subtask in enumerate(subtasks.copy()):
+                if subtask['id'] == subtask_end.group(1):
+                    for subt_idx, existed_subt in enumerate(commands_threads[
+                            subtask['parent_thread']][
+                            subtask['task_idx']]['subtasks']):
+                        if (existed_subt['id'] == subtask_end.group(1)):
+                            commands_threads[subtask['parent_thread']][
+                                subtask['task_idx']]['subtasks'][
+                                    subt_idx]['end_time'] = dt
+                            commands_threads[subtask['parent_thread']][
+                                subtask['task_idx']]['subtasks'][
+                                    subt_idx]['duration'] = dt - \
+                                        commands_threads[subtask[
+                                        'parent_thread']][
+                                        subtask['task_idx']]['subtasks'][
+                                        subt_idx]['start_time']
+                    subtasks.remove(subtask)
     f.close()
-    # json.dump(commands_threads, open('tasks_engine_' +
-    #                                  log_directory.split('/')[-2] +
-    #                                  '.json',
-    #                                  'w'), indent=4, sort_keys=True)
+    json.dump(commands_threads, open('tasks_engine_' +
+                                     log_directory.split('/')[-2] +
+                                     '.json',
+                                     'w'), indent=4, sort_keys=True)
     if commands_threads != {}:
         commands_threads, long_actions = select_needed_commands(
                                             commands_threads, needed_threads)
-    # json.dump(commands_threads, open('filtered_tasks_engine_' +
-    #                                  log_directory.split('/')[-2] +
-    #                                  '.json',
-    #                                  'w'), indent=4, sort_keys=True)
-    return commands_threads, long_actions
+    json.dump(commands_threads, open('filtered_tasks_engine_' +
+                                     log_directory.split('/')[-2] +
+                                     '.json',
+                                     'w'), indent=4, sort_keys=True)
+    return commands_threads, long_actions, subtasks_ids
 
 
 def find_vm_tasks_libvirtd(positions,
@@ -578,7 +689,7 @@ def find_vm_tasks_libvirtd(positions,
                            file_formats,
                            tz_info,
                            time_range_info,
-                           user_vms, user_hosts):
+                           user_vms, user_hosts, additive):
     commands_threads = {}
     long_actions = []
     needed_threads = set()
@@ -612,8 +723,17 @@ def find_vm_tasks_libvirtd(positions,
                 continue
             if (dt > time_range_info[tr_idx][1]):
                 break
-            if (any([vm in fields["message"] for vm in user_vms]) or
-                    any([host in fields["message"] for host in user_hosts])):
+            if additive:
+                condition = (any([vm in fields["message"] \
+                                  for vm in user_vms]) \
+                             or any([host in fields["message"] \
+                                     for host in user_hosts]))
+            else:
+                condition = (any([vm in fields["message"] \
+                                  for vm in user_vms]) \
+                             and any([host in fields["message"] \
+                                      for host in user_hosts]))
+            if (condition):
                 needed_threads.add(fields["thread"])
             start = re.search(r"Thread (.+?) \((.+?)\) is now running " +
                               r"job (.+)", line)
@@ -622,6 +742,7 @@ def find_vm_tasks_libvirtd(positions,
                     commands_threads[start.group(1)] = []
                 commands_threads[start.group(1)] += [
                                  {'command_name': start.group(3),
+                                  'command_start_name': start.group(3),
                                   'start_time': dt}]
                 continue
             finish = re.search(r"Thread (.+?) \((.+?)\) finished job (.+?)" +
@@ -629,7 +750,8 @@ def find_vm_tasks_libvirtd(positions,
             if (finish is not None):
                 if (finish.group(1) not in commands_threads.keys()):
                     commands_threads[finish.group(1)] = [
-                                     {'command_name': finish.group(3)}]
+                                     {'command_name': finish.group(3),
+                                      'command_start_name': finish.group(3)}]
                     continue
                 else:
                     com_list = [com['command_name'] for com in
@@ -639,7 +761,8 @@ def find_vm_tasks_libvirtd(positions,
                                  com_list[::-1].index(finish.group(3))
                     except:
                         commands_threads[finish.group(1)] += [{
-                                         'command_name': finish.group(3)}]
+                                         'command_name': finish.group(3),
+                                         'command_start_name': finish.group(3)}]
                         com_id = -1
                 commands_threads[finish.group(1)][com_id]['finish_time'] = dt
                 if ('start_time' in commands_threads[
@@ -650,17 +773,17 @@ def find_vm_tasks_libvirtd(positions,
                         commands_threads[finish.group(1)][
                                          com_id]['start_time']
     f.close()
-    # json.dump(commands_threads, open('tasks_libvirtd_' +
-    #                                  log_directory.split('/')[-2] +
-    #                                  '.json',
-    #                                  'w'), indent=4, sort_keys=True)
+    json.dump(commands_threads, open('tasks_libvirtd_' +
+                                     log_directory.split('/')[-2] +
+                                     '.json',
+                                     'w'), indent=4, sort_keys=True)
     if commands_threads != {}:
         commands_threads, long_actions = select_needed_commands(
                                             commands_threads, needed_threads)
-    # json.dump(commands_threads, open('filtered_tasks_libvirtd_' +
-    #                                  log_directory.split('/')[-2] +
-    #                                  '.json',
-    #                                  'w'), indent=4, sort_keys=True)
+    json.dump(commands_threads, open('filtered_tasks_libvirtd_' +
+                                     log_directory.split('/')[-2] +
+                                     '.json',
+                                     'w'), indent=4, sort_keys=True)
     return commands_threads, long_actions
 
 
@@ -673,23 +796,22 @@ def select_needed_commands(all_threads, needed_threads):
             vm_threads[thread] = all_threads[thread]
         for command in all_threads[thread]:
             if ('duration' in command.keys()):
-                if command['command_name'] not in \
-                        operations_time.keys():
-                    operations_time[command['command_name']] = []
-                operations_time[command['command_name']] += \
+                if command['command_start_name'] not in operations_time.keys():
+                    operations_time[command['command_start_name']] = []
+                operations_time[command['command_start_name']] += \
                     [{'duration': command['duration'], 'start_time':
                      command['start_time']}]
-    commands_ex_time = [t['duration'] for c in operations_time
-                        for t in operations_time[c]]
-    ex_median = np.median(commands_ex_time)
-    ex_std = np.std(commands_ex_time)
+    # commands_ex_time = [t['duration'] for c in operations_time
+    #                     for t in operations_time[c]]
+    # ex_median = np.median(commands_ex_time)
+    # ex_std = np.std(commands_ex_time)
     for command in sorted(operations_time.keys()):
         com_time = [c_id['duration'] for c_id in operations_time[command]]
         med_com_time = np.median(com_time)
         std_com_time = np.std(com_time)
         for c_id in operations_time[command]:
-            if ((c_id['duration'] > med_com_time + 3*std_com_time) or
-                    (c_id['duration'] > ex_median + 3*ex_std)):
+            if ((c_id['duration'] > med_com_time + 3*std_com_time
+                    and c_id['duration'] > 1) or c_id['duration'] > 5):
                 if command not in long_operations.keys():
                     long_operations[command] = []
                 long_operations[command] += [c_id['start_time']]
@@ -698,10 +820,10 @@ def select_needed_commands(all_threads, needed_threads):
             found = False
             if 'duration' not in command.keys():
                 continue
-            if command['command_name'] not in long_operations.keys():
+            if command['command_start_name'] not in long_operations.keys():
                 continue
             if command['start_time'] not in long_operations[command[
-                                            'command_name']]:
+                                            'command_start_name']]:
                 continue
             if thread not in vm_threads.keys():
                 vm_threads[thread] = [command]
@@ -709,10 +831,10 @@ def select_needed_commands(all_threads, needed_threads):
             for existed_commands in vm_threads[thread]:
                 if 'duration' not in existed_commands.keys():
                     continue
-                if existed_commands['command_name'] == \
-                        command['command_name'] and \
-                        existed_commands['start_time'] == \
-                        command['start_time']:
+                if (existed_commands['command_start_name'] ==
+                        command['command_start_name']
+                        and existed_commands['start_time'] ==
+                        command['start_time']):
                     found = True
             if found:
                 continue

--- a/src/lib/detect_running_components.py
+++ b/src/lib/detect_running_components.py
@@ -178,7 +178,6 @@ def find_needed_linenum(output_descriptor, log_directory, files, tz_info,
                     or (prev_time > needed_time) \
                     and (cur_time <= needed_time) \
                     or (cur_time == prev_time)
-                #if condition and prev_time-cur_time > 
             needed_linenum[log] += [min(prev_pos, cur_pos)]
     return needed_linenum
 
@@ -200,8 +199,8 @@ def libvirtd_vm_host(f, filename, pos, tz_info, vms, hosts,
             dt = parse_date_time(f.readline(), tz_info)
     f.seek(real_firstpos, os.SEEK_SET)
     widget_style = [filename + ':', progressbar.Percentage(), ' (',
-                              progressbar.SimpleProgress(), ')', ' ',
-                              progressbar.Bar(), ' ', progressbar.Timer()]
+                    progressbar.SimpleProgress(), ')', ' ',
+                    progressbar.Bar(), ' ', progressbar.Timer()]
     bar = ProgressBar(widgets=widget_style, max_value=file_len)
     i = real_firstpos
     bar.update(i)
@@ -262,8 +261,7 @@ def libvirtd_vm_host(f, filename, pos, tz_info, vms, hosts,
     return vms, hosts, real_firstpos
 
 
-def vdsm_vm_host(f, filename, pos, tz_info, vms, hosts,
-                     time_range_info):
+def vdsm_vm_host(f, filename, pos, tz_info, vms, hosts, time_range_info):
     cur = {}
     f.seek(0, os.SEEK_END)
     file_len = f.tell()
@@ -278,8 +276,8 @@ def vdsm_vm_host(f, filename, pos, tz_info, vms, hosts,
             dt = parse_date_time(f.readline(), tz_info)
     f.seek(real_firstpos, os.SEEK_SET)
     widget_style = [filename + ':', progressbar.Percentage(), ' (',
-                              progressbar.SimpleProgress(), ')', ' ',
-                              progressbar.Bar(), ' ', progressbar.Timer()]
+                    progressbar.SimpleProgress(), ')', ' ',
+                    progressbar.Bar(), ' ', progressbar.Timer()]
     bar = ProgressBar(widgets=widget_style, max_value=file_len,
                       redirect_stdout=True)
     i = real_firstpos
@@ -297,7 +295,7 @@ def vdsm_vm_host(f, filename, pos, tz_info, vms, hosts,
         if vdsm_host is not None:
             this_host = vdsm_host.group(2)
             if (this_host not in hosts.keys()):
-                hosts[this_host] = {'id': set(), 'vmids': set()}        
+                hosts[this_host] = {'id': set(), 'vmids': set()}
         vm_name = re.search(r'\<name\>(.+?)\<\/name\>', line)
         if (not multiline and vm_name is not None):
             multiline = True
@@ -327,6 +325,7 @@ def vdsm_vm_host(f, filename, pos, tz_info, vms, hosts,
     bar.finish()
     return vms, hosts, real_firstpos
 
+
 def engine_vm_host(f, filename, pos, tz_info, vms, hosts, time_range_info):
     f.seek(0, os.SEEK_END)
     file_len = f.tell()
@@ -339,8 +338,8 @@ def engine_vm_host(f, filename, pos, tz_info, vms, hosts, time_range_info):
             dt = parse_date_time(f.readline(), tz_info)
     f.seek(real_firstpos, os.SEEK_SET)
     widget_style = [filename + ':', progressbar.Percentage(), ' (',
-                              progressbar.SimpleProgress(), ')', ' ',
-                              progressbar.Bar(), ' ', progressbar.Timer()]
+                    progressbar.SimpleProgress(), ')', ' ',
+                    progressbar.Bar(), ' ', progressbar.Timer()]
     bar = ProgressBar(widgets=widget_style, max_value=file_len)
     i = real_firstpos
     bar.update(i)
@@ -368,33 +367,33 @@ def engine_vm_host(f, filename, pos, tz_info, vms, hosts, time_range_info):
                 vm_id = ''
             if (re.search(r"vmName\ *=\ *(.+?),", line) is not None):
                 vm_name = re.sub('[\'\"]', '',
-                                  re.search(r"vmName\ *=\ *(.+?),",
-                                            line).group(1))
+                                 re.search(r"vmName\ *=\ *(.+?),",
+                                           line).group(1))
             elif (re.search(r"vm\ *=\ *\'VM\ *\[([^\[\]]*?)\]\'",
                             line) is not None):
                 vm_name = re.sub('[\'\"]', '',
-                                  re.search(r"vm\ *=\ *\'VM\ *" +
-                                            r"\[([^\[\]]*?)\]\'",
-                                            line).group(1))
+                                 re.search(r"vm\ *=\ *\'VM\ *" +
+                                           r"\[([^\[\]]*?)\]\'",
+                                           line).group(1))
             elif (re.search(r"\[(.+?)=VM_NAME\]", line) is not None):
                 vm_name = re.sub('[\'\"]', '',
-                                  re.search(r"\[([^\[\]]*?)=VM_NAME\]",
-                                            line).group(1))
+                                 re.search(r"\[([^\[\]]*?)=VM_NAME\]",
+                                           line).group(1))
             elif (re.search(r"\[(.+?)=VM\]", line) is not None):
                 vm_name = re.sub('[\'\"]', '',
-                                  re.search(r"\[([^\[\]]*?)=VM\]",
-                                            line).group(1))
+                                 re.search(r"\[([^\[\]]*?)=VM\]",
+                                           line).group(1))
             elif (re.search(r"\'vmName\'\ *[:=]\ *u*\'([^\']*?)\'",
                             line) is not None):
                 vm_name = re.sub('[\'\"]', '',
-                                  re.search(r"\'vmName\'" +
-                                            r"\ *[:=]\ *u*\'([^\']*?)\'",
-                                            line).group(1))
+                                 re.search(r"\'vmName\'" +
+                                           r"\ *[:=]\ *u*\'([^\']*?)\'",
+                                           line).group(1))
             else:
                 vm_name = ''
         if (vm_name == '' and vm_id == ''):
             other_vm = re.search(r'VM\ *\'(.{30,40}?)\'\ *' +
-                             r'\(([^\(\)]*?)\)', line)
+                                 r'\(([^\(\)]*?)\)', line)
             if (other_vm is not None):
                 vm_name = other_vm.group(2)
                 vm_id = other_vm.group(1)
@@ -439,9 +438,6 @@ def timeline_for_engine_vm(output_directory, log_directory, f, filename,
         all_vms[vm] = {}
         for host in vms[vm]['hostids']:
             all_vms[vm][host] = []
-    f.seek(0, os.SEEK_END)
-    file_len = f.tell()
-    f.seek(0, os.SEEK_SET)
     for line_num, line in enumerate(f):
         dt = parse_date_time(line, tz_info)
         if dt == 0:
@@ -469,7 +465,7 @@ def timeline_for_engine_vm(output_directory, log_directory, f, filename,
                                     r'\ +\(VM\:\ +([^\ ]+),\ +[Ss]ource\:' +
                                     r'\ +([^\ ]+)\,\ +[Dd]estination\:\ +' +
                                     r'([^\ ]+?)[\ +\,]+',
-                             line)
+                                    line)
         if migration_start is not None:
             this_host = ''
             if migration_start.group(1) not in all_vms.keys():
@@ -492,10 +488,10 @@ def timeline_for_engine_vm(output_directory, log_directory, f, filename,
                     this_host] += [(dt, 'migrating_to')]
         # migration completed
         migration_end = re.search(r'[Mm]essage\:\ +[Mm]igration\ +completed' +
-                                    r'\ +\(VM\:\ +([^\ ]+),\ +[Ss]ource\:' +
-                                    r'\ +([^\ ]+)\,\ +[Dd]estination\:\ +' +
-                                    r'([^\ ]+?)[\ +\,]+',
-                             line)
+                                  r'\ +\(VM\:\ +([^\ ]+),\ +[Ss]ource\:' +
+                                  r'\ +([^\ ]+)\,\ +[Dd]estination\:\ +' +
+                                  r'([^\ ]+?)[\ +\,]+',
+                                  line)
         if migration_end is not None:
             this_host = ''
             if migration_end.group(1) not in all_vms.keys():
@@ -534,7 +530,7 @@ def timeline_for_engine_vm(output_directory, log_directory, f, filename,
             all_vms[vm_suspend.group(1)][this_host] += [(dt, 'suspend')]
         # down
         vm_down = re.search(r'[Mm]essage\:\ +VM\ +([^\ ]+)\ +is [Dd]own',
-                                    line)
+                            line)
         if vm_down is not None:
             if vm_down.group(1) not in all_vms.keys():
                 all_vms[vm_down.group(1)] = {}
@@ -543,9 +539,9 @@ def timeline_for_engine_vm(output_directory, log_directory, f, filename,
     if all_vms != {}:
         all_vms = create_time_ranges_for_vms(all_vms)
     json.dump(all_vms, open(os.path.join(output_directory,
-                                     filename +
-                                     '_VMs_timeline.json'),
-                                     'w'), indent=4, sort_keys=True)
+                            filename +
+                            '_VMs_timeline.json'),
+                            'w'), indent=4, sort_keys=True)
     return all_vms
 
 
@@ -582,10 +578,11 @@ def create_time_ranges_for_vms(vms):
                     cur_range = {}
             if ('start' in cur_range.keys()
                     and 'end' not in cur_range.keys()):
-                host_time += [[cur_range['start'], cur_range['start']*2]]  # fix
+                host_time += [[cur_range['start'], cur_range['start']*2]]
             if host_time != []:
                 vm_time_range[vm_name][host_name] = host_time
     return vm_time_range
+
 
 def find_all_vm_host(positions,
                      output_descriptor,
@@ -613,8 +610,8 @@ def find_all_vm_host(positions,
             if 'vdsm' in log.lower():
                 vms, hosts, firstline_pos = \
                     vdsm_vm_host(f, log, 0,  # log_position,
-                                     tz_info[log_idx], vms, hosts,
-                                     time_range_info[tr_idx])
+                                 tz_info[log_idx], vms, hosts,
+                                 time_range_info[tr_idx])
             elif 'libvirt' in log.lower():
                 vms, hosts, firstline_pos = \
                     libvirtd_vm_host(f, log, 0,  # log_position,
@@ -673,7 +670,7 @@ def find_all_vm_host(positions,
             hosts[k]['vmids'].remove('')
     vms_timeline = {}
     for log_idx, log in enumerate(files):
-        if not 'engine' in log:
+        if 'engine' not in log:
             continue
         full_filename = os.path.join(log_directory, log)
         if log[-4:] == '.log':
@@ -691,7 +688,7 @@ def find_all_vm_host(positions,
                                                   hosts)
             vms_timeline.update(cur_timeline)
     return vms, hosts, not_running_vms, not_found_vmnames, \
-            not_found_hostnames, first_lines, vms_timeline
+        not_found_hostnames, first_lines, vms_timeline
 
 
 def find_vm_tasks_engine(positions, output_descriptor, log_directory,
@@ -723,8 +720,8 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
     f.seek(0, os.SEEK_END)
     file_len = f.tell()
     widget_style = [log + ':', progressbar.Percentage(), ' (',
-                              progressbar.SimpleProgress(), ')', ' ',
-                              progressbar.Bar(), ' ', progressbar.Timer()]
+                    progressbar.SimpleProgress(), ')', ' ',
+                    progressbar.Bar(), ' ', progressbar.Timer()]
     bar = ProgressBar(widgets=widget_style, max_value=file_len)
     for tr_idx, pos in enumerate(positions):
         f.seek(pos, os.SEEK_SET)
@@ -774,7 +771,7 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                                       'start_line_num': line_num + 1}]
                 else:
                     flow_list = [com['flow_id'] for com in
-                                commands_threads[start.group(1)]]
+                                 commands_threads[start.group(1)]]
                     try:
                         com_id = len(flow_list) - 1 - \
                                  flow_list[::-1].index(start.group(1))
@@ -807,11 +804,10 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                         enumerate(commands_threads[finish.group(1)]):
                     if ('log_id' in command.keys() and
                             command['log_id'] == finish.group(4)):
-                        commands_threads[finish.group(1)][
-                                                task_idx]['finish_time'] = dt
-                        commands_threads[finish.group(1)][
-                                                task_idx][
-                                                'finish_line_num'] = line_num + 1
+                        commands_threads[finish.group(1)][task_idx][
+                            'finish_time'] = dt
+                        commands_threads[finish.group(1)][task_idx][
+                            'finish_line_num'] = line_num + 1
                         if ('start_time' in commands_threads[
                                 finish.group(1)][task_idx].keys()):
                             commands_threads[finish.group(1)][
@@ -854,9 +850,9 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                     commands_threads[thr_list[com_id][0]][
                             thr_list[com_id][1]]['end_line_num'] = line_num + 1
                     commands_threads[thr_list[com_id][0]][
-                                thr_list[com_id][1]]['duration_full'] = dt - \
-                    commands_threads[thr_list[com_id][0]][
-                                thr_list[com_id][1]]['init_time']
+                        thr_list[com_id][1]]['duration_full'] = dt - \
+                        commands_threads[thr_list[com_id][0]][thr_list[
+                            com_id][1]]['init_time']
                 continue
             multiasync = re.search(r"\((.+?)\)\ +\[(.*?)\].+" +
                                    r"[Aa]dding\ +CommandMultiAsyncTasks\ +" +
@@ -871,9 +867,9 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                               'first_line_num': line_num + 1}
                 continue
             subtask_init = re.search(r"\((.+?)\)\ +\[(.*?)\].+" +
-                                r"[Aa]ttaching [Tt]ask\ +\'(.+?)\'\ +" +
-                                r"[Tt]o [Cc]ommand\ +\'(.+?)\'",
-                                line)
+                                     r"[Aa]ttaching [Tt]ask\ +\'(.+?)\'\ +" +
+                                     r"[Tt]o [Cc]ommand\ +\'(.+?)\'",
+                                     line)
             if subtask_init is not None:
                 if (subtask_init.group(4) not in commands.keys()):
                     commands[subtask_init.group(4)] = {
@@ -905,7 +901,7 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                                         'first_line_num': line_num + 1}
                     continue
                 tasks[subtask_start.group(3)]['parent_name'] = \
-                                                        subtask_start.group(4)
+                    subtask_start.group(4)
                 tasks[subtask_start.group(3)]['start_time'] = dt
                 continue
             # wait
@@ -925,7 +921,7 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                                             'first_line_num': line_num + 1}
                 commands[subtask_wait.group(4)]['name'] = subtask_wait.group(3)
                 if (subtask_wait.group(5) in commands.keys()
-                        and commands[subtask_wait.group(5)]['name'] != 
+                        and commands[subtask_wait.group(5)]['name'] !=
                         subtask_wait.group(6)):
                     commands[subtask_wait.group(5)] = {
                                             'name': subtask_wait.group(6),
@@ -938,9 +934,9 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                                     {'child_id': subtask_wait.group(5),
                                      'child_name': subtask_wait.group(6)}]
                     continue
-                if (subtask_wait.group(5) not in 
-                        [child['child_id'] for child in 
-                        commands[subtask_wait.group(4)]['childs']]):
+                if (subtask_wait.group(5) not in
+                        [child['child_id'] for child in
+                         commands[subtask_wait.group(4)]['childs']]):
                     commands[subtask_wait.group(4)]['childs'] += [
                                         {'child_id': subtask_wait.group(5),
                                          'child_name': subtask_wait.group(6)}]
@@ -956,7 +952,7 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                 tasks[subtask_end.group(3)]['end_line_num'] = line_num + 1
                 if ('start_time' in tasks[subtask_end.group(3)].keys()):
                     tasks[subtask_end.group(3)]['duration'] = dt - \
-                                    tasks[subtask_end.group(3)]['start_time']    
+                        tasks[subtask_end.group(3)]['start_time']
                 continue
     f.close()
     bar.finish()
@@ -987,7 +983,7 @@ def find_vm_tasks_engine(positions, output_descriptor, log_directory,
                                                             needed_linenum,
                                                             reasons)
     return commands_threads, long_actions, new_commands, command_lvl, \
-           needed_linenum, reasons
+        needed_linenum, reasons
 
 
 def link_commands(log_dir, output_descriptor, commands, command_lvl,
@@ -1039,16 +1035,16 @@ def link_commands(log_dir, output_descriptor, commands, command_lvl,
                                 and 'childs' not in
                                 commands[child['child_id']].keys()):
                             new_commands[parent]['zchildren'] += \
-                                            [new_commands[child['child_id']]]
+                                [new_commands[child['child_id']]]
                             new_commands[parent]['zchildren'][-1]['id'] = \
-                                            child['child_id']
+                                child['child_id']
                             if child['child_id'] in commands.keys():
                                 commands.pop(child['child_id'])
                             if child['child_id'] in new_commands.keys():
-                               new_commands.pop(child['child_id'])
+                                new_commands.pop(child['child_id'])
                 break
     heads = []
-    while (len(commands)>0):
+    while(len(commands) > 0):
         for idx, command_id in enumerate(sorted(new_commands.keys())):
             if command_id in heads:
                 continue
@@ -1073,14 +1069,13 @@ def link_commands(log_dir, output_descriptor, commands, command_lvl,
                             and 'childs' not in
                             commands[child['child_id']].keys()):
                         new_commands[parent]['zchildren'] += \
-                                            [new_commands[child['child_id']]]
+                            [new_commands[child['child_id']]]
                         new_commands[parent]['zchildren'][-1]['id'] = \
-                                            child['child_id']
+                            child['child_id']
                         new_commands[parent]['lvl'] = \
-                                            new_commands[child['child_id']][
-                                            'lvl'] + 1
+                            new_commands[child['child_id']]['lvl'] + 1
                         command_lvl[parent] = new_commands[child['child_id']][
-                                            'lvl'] + 1
+                                                           'lvl'] + 1
                         if child['child_id'] in commands.keys():
                             commands.pop(child['child_id'])
                         if child['child_id'] in new_commands.keys():
@@ -1097,12 +1092,12 @@ def link_commands(log_dir, output_descriptor, commands, command_lvl,
 def find_parent(output_descriptor, commands, command_id):
     parent = None
     for com in sorted(commands.keys()):
-        if ('childs' in commands[com].keys()
-                and command_id in [c['child_id']
-                for c in commands[com]['childs']]):
+        if ('childs' in commands[com].keys() and command_id in
+                [c['child_id'] for c in commands[com]['childs']]):
             parent = com
             break
     return parent
+
 
 def find_vm_tasks_libvirtd(positions, output_descriptor, log_directory,
                            log, file_formats, tz_info, time_range_info,
@@ -1132,8 +1127,8 @@ def find_vm_tasks_libvirtd(positions, output_descriptor, log_directory,
     f.seek(0, os.SEEK_END)
     file_len = f.tell()
     widget_style = [log + ':', progressbar.Percentage(), ' (',
-                              progressbar.SimpleProgress(), ')', ' ',
-                              progressbar.Bar(), ' ', progressbar.Timer()]
+                    progressbar.SimpleProgress(), ')', ' ',
+                    progressbar.Bar(), ' ', progressbar.Timer()]
     bar = ProgressBar(widgets=widget_style, max_value=file_len)
     for tr_idx, pos in enumerate(positions):
         f.seek(pos, os.SEEK_SET)
@@ -1188,7 +1183,7 @@ def find_vm_tasks_libvirtd(positions, output_descriptor, log_directory,
                         commands_threads[finish.group(1)][
                                          com_id]['start_time']
                 continue
-            #qemu monitor
+            # qemu monitor
             send_monitor = re.search(r"mon\ *=\ *(.+?)\ +buf\ *\=\ *" +
                                      r"\{\"execute.+\"id\"\:\ *\"(.+?)\"\}",
                                      line)
@@ -1196,7 +1191,7 @@ def find_vm_tasks_libvirtd(positions, output_descriptor, log_directory,
                 if (send_monitor.group(1) not in qemu_monitor.keys()):
                     qemu_monitor[send_monitor.group(1)] = []
                 qemu_monitor[send_monitor.group(1)] += [
-                                            {'send_time': dt, 
+                                            {'send_time': dt,
                                              'id': send_monitor.group(2),
                                              'start_line_num':
                                              str(line_num + 1),
@@ -1296,69 +1291,51 @@ def find_long_operations(all_threads, needed_linenum, reasons):
                     long_operations[command] = []
                 long_operations[command] += [c_id['start_time']]
                 needed_linenum.add(c_id['log'] + ':' +
-                                                str(c_id['start_line_num']))
+                                   str(c_id['start_line_num']))
                 needed_linenum.add(c_id['log'] + ':' +
-                                                str(c_id['finish_line_num']))
+                                   str(c_id['finish_line_num']))
                 if (c_id['log'] + ':' + str(c_id['start_line_num'])
                         not in reasons.keys()):
-                    reasons[c_id['log'] + ':' + str(c_id['start_line_num'])] = set()
-                reasons[c_id['log'] + ':' + str(c_id['start_line_num'])].add('Task (duration=' +
-                                          str(np.round(c_id['duration'], 2)) + ')')
+                    reasons[c_id['log'] + ':' +
+                            str(c_id['start_line_num'])] = set()
+                reasons[c_id['log'] + ':' + str(c_id['start_line_num'])].add(
+                    'Task (duration=' + str(np.round(c_id['duration'], 2)) +
+                    ')')
                 if (c_id['log'] + ':' + str(c_id['finish_line_num'])
                         not in reasons.keys()):
-                    reasons[c_id['log'] + ':' + str(c_id['finish_line_num'])] = set()
-                reasons[c_id['log'] + ':' + str(c_id['finish_line_num'])].add('Task (duration=' +
-                                          str(np.round(c_id['duration'], 2)) + ')')
+                    reasons[c_id['log'] + ':' +
+                            str(c_id['finish_line_num'])] = set()
+                reasons[c_id['log'] + ':' + str(c_id['finish_line_num'])].add(
+                    'Task (duration=' + str(np.round(c_id['duration'], 2)) +
+                    ')')
     for command in sorted(full_operations_time.keys()):
-        com_time = [c_id['duration_full'] for c_id in full_operations_time[command]]
+        com_time = [c_id['duration_full']
+                    for c_id in full_operations_time[command]]
         med_com_time = np.median(com_time)
         std_com_time = np.std(com_time)
         for c_id in full_operations_time[command]:
             if ((c_id['duration_full'] > med_com_time + 3*std_com_time
-                    and c_id['duration_full'] > 1) or c_id['duration_full'] > 5):
+                    and c_id['duration_full'] > 1)
+                    or c_id['duration_full'] > 5):
                 if command not in long_operations.keys():
                     long_operations[command] = []
                 long_operations[command] += [c_id['init_time']]
-                needed_linenum.add(c_id['log'] + ':' + str(c_id['init_line_num']))
-                needed_linenum.add(c_id['log'] + ':' + str(c_id['end_line_num']))
-                if c_id['log'] + ':' + str(c_id['init_line_num']) not in reasons.keys():
-                    reasons[c_id['log'] + ':' + str(c_id['init_line_num'])] = set()
-                reasons[c_id['log'] + ':' + str(c_id['init_line_num'])].add('Task (duration=' +
-                                     str(np.round(c_id['duration_full'], 2)) + ')')
-                if c_id['log'] + ':' + str(c_id['end_line_num']) not in reasons.keys():
-                    reasons[c_id['log'] + ':' + str(c_id['end_line_num'])] = set()
-                reasons[c_id['log'] + ':' + str(c_id['end_line_num'])].add('Task (duration=' +
-                                     str(np.round(c_id['duration_full'], 2)) + ')')
+                needed_linenum.add(c_id['log'] + ':' +
+                                   str(c_id['init_line_num']))
+                needed_linenum.add(c_id['log'] + ':' +
+                                   str(c_id['end_line_num']))
+                if (c_id['log'] + ':' + str(c_id['init_line_num'])
+                        not in reasons.keys()):
+                    reasons[c_id['log'] + ':' +
+                            str(c_id['init_line_num'])] = set()
+                reasons[c_id['log'] + ':' + str(c_id['init_line_num'])].add(
+                    'Task (duration=' + str(np.round(c_id[
+                        'duration_full'], 2)) + ')')
+                if (c_id['log'] + ':' + str(c_id['end_line_num'])
+                        not in reasons.keys()):
+                    reasons[c_id['log'] + ':' +
+                            str(c_id['end_line_num'])] = set()
+                reasons[c_id['log'] + ':' + str(c_id['end_line_num'])].add(
+                            'Task (duration=' + str(np.round(c_id[
+                                'duration_full'], 2)) + ')')
     return long_operations, needed_linenum, reasons
-
-
-# def return_numbers_of_needed_lines(long_operations, all_threads, log):
-#     needed_linenum = set()
-#     reasons = {}
-#     for thread in all_threads:
-#         for command in all_threads[thread]:
-#             if ('start_line_num' in command.keys()
-#                     and 'finish_line_num' in command.keys()):
-#                 for linenum in range(command['start_line_num'],
-#                                      command['finish_line_num']):
-#                     needed_linenum.add(log + ':' + str(linenum))
-#                     if log + ':' + str(linenum) not in reasons.keys():
-#                         reasons[log + ':' + str(linenum)] = set()
-#                     reasons[log + ':' + str(linenum)].add('Task')
-#                     if (command['command_start_name'] in long_operations.keys()
-#                             and command['start_time'] in
-#                             long_operations[command['command_start_name']]):
-#                         reasons[log + ':' + str(linenum)].add('Long operation')
-#             elif ('init_line_num' in command.keys()
-#                     and 'end_line_num' in command.keys()):
-#                 for linenum in range(command['init_line_num'],
-#                                      command['end_line_num']):
-#                     needed_linenum.add(log + ':' + str(linenum))
-#                     if log + ':' + str(linenum) not in reasons.keys():
-#                         reasons[log + ':' + str(linenum)] = set()
-#                     reasons[log + ':' + str(linenum)].add('Task')
-#                     if (command['command_name'] in long_operations.keys()
-#                             and command['init_time'] in
-#                             long_operations[command['command_name']]):
-#                         reasons[log + ':' + str(linenum)].add('Long operation')
-#     return needed_linenum, reasons

--- a/src/lib/errors_statistics.py
+++ b/src/lib/errors_statistics.py
@@ -1,5 +1,6 @@
 """ Linking errors from logfiles to each other
 """
+import os
 import numpy as np
 import re
 from datetime import datetime
@@ -39,7 +40,7 @@ def merge_all_errors_by_time(all_errors, fields_names):
 
 def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                         user_hosts, subtasks, dirname, err_timeline, vm_tasks,
-                        long_tasks, all_vms, all_hosts):
+                        long_tasks, all_vms, all_hosts, output_directory):
     keywords = user_vms  # user_events + user_vms + user_hosts
     template = re.compile(\
                           # r"[^^][^\ \t\,\;\=]{20,}|" +
@@ -84,14 +85,15 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                 if all_errors[err_id][strid] not in reasons.keys():
                     reasons[all_errors[err_id][strid]] = set()
                 reasons[all_errors[err_id][strid]].add('VM, Host or Task ID')
-        # print(subtasks)
-        for t in subtasks:
+        for t in subtasks.keys():
             if t in all_errors[err_id][msid]:
                 # Check if user-defined words are in the message
                 needed_msgs.add(all_errors[err_id][strid])
                 if all_errors[err_id][strid] not in reasons.keys():
                     reasons[all_errors[err_id][strid]] = set()
-                reasons[all_errors[err_id][strid]].add('Subtask')
+                reasons[all_errors[err_id][strid]].add('Task/' +
+                                                            str(subtasks[t]))
+                break
         for k in ['error', 'fail', 'failure', 'failed', 'traceback',
                   'warn', 'warning', 'could not', 'exception', 'down',
                   'crash']:
@@ -119,7 +121,8 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
         new_events[word_key]['keywords'].union(events[shorten]['keywords'])
     events = new_events
     del new_events
-    f = open("clusters_"+dirname.split('/')[-2]+".txt", 'w')
+    f = open(os.path.join(output_directory,
+             dirname.split('/')[-2]+"_clusters.txt"), 'w')
     for c_id, clust in enumerate(sorted(events.keys())):
         for mes in events[clust]['data']:
             f.write("%d : %s\n" % (c_id, mes[msid]))
@@ -204,7 +207,8 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
     new_fields = ['date_time', 'line_num', 'reason', 'message']
     if reasons == {}:
         return msg_showed, new_fields
-    f = open('diff.txt', 'w')
+    f = open(os.path.join(output_directory,
+             dirname.split('/')[-2]+'_diff.txt'), 'w')
     max_len = max([len('_'.join(reasons[r])) for r in reasons.keys()])
     for msg in all_errors:
         if msg[strid] in needed_msgs:

--- a/src/lib/errors_statistics.py
+++ b/src/lib/errors_statistics.py
@@ -43,8 +43,7 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                         long_tasks, output_directory, detail_reasons,
                         needed_msgs, criterias, vm_timeline):
     reasons = {}
-    template = re.compile(\
-                          r"[^^](\"[^\"]{20,}\")|" +
+    template = re.compile(r"[^^](\"[^\"]{20,}\")|" +
                           r"[^^](\'[^\']{20,}\')|" +
                           r"[^^](\(+.*\)+)|" +
                           r"[^^](\[+.*\]+)|" +
@@ -91,7 +90,8 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                     needed_msgs.add(all_errors[err_id][strid])
                     if all_errors[err_id][strid] not in detail_reasons.keys():
                         detail_reasons[all_errors[err_id][strid]] = set()
-                    detail_reasons[all_errors[err_id][strid]].add('Event=' + event)
+                    detail_reasons[all_errors[err_id][strid]].add('Event=' +
+                                                                  event)
         if 'VM id' in criterias:
             for vm_name in user_vms:
                 if (vm_name in vm_timeline.keys()
@@ -99,7 +99,8 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                     needed_msgs.add(all_errors[err_id][strid])
                     if all_errors[err_id][strid] not in detail_reasons.keys():
                         detail_reasons[all_errors[err_id][strid]] = set()
-                    detail_reasons[all_errors[err_id][strid]].add('VM=' + vm_name )
+                    detail_reasons[all_errors[err_id][strid]].add('VM=' +
+                                                                  vm_name)
         if 'Host id' in criterias:
             for host_name in user_hosts:
                 if (host_name in all_errors[err_id][msid]
@@ -108,7 +109,8 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                     needed_msgs.add(all_errors[err_id][strid])
                     if all_errors[err_id][strid] not in detail_reasons.keys():
                         detail_reasons[all_errors[err_id][strid]] = set()
-                    detail_reasons[all_errors[err_id][strid]].add('Host=' + host_name)
+                    detail_reasons[all_errors[err_id][strid]].add('Host=' +
+                                                                  host_name)
         if 'Subtasks' in criterias:
             for t in subtasks.keys():
                 if t in all_errors[err_id][msid]:
@@ -117,15 +119,17 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                     if all_errors[err_id][strid] not in reasons.keys():
                         reasons[all_errors[err_id][strid]] = set()
                     reasons[all_errors[err_id][strid]].add('Task/' +
-                                                                str(subtasks[t]))
+                                                           str(subtasks[t]))
                     break
         if 'Error or warning' in criterias:
             for k in ['error', 'fail', 'failure', 'failed', 'traceback',
                       'warn', 'warning', 'could not', 'exception', 'down',
                       'crash']:
                 for field_id, f in enumerate(fields):
-                    err_res = re.search(r'(^|[ \:\.\,]+)' + k + r'([ \:\.\,=]+|$)',
-                                        str(all_errors[err_id][field_id]).lower())
+                    err_res = re.search(r'(^|[ \:\.\,]+)' + k +
+                                        r'([ \:\.\,=]+|$)',
+                                        str(all_errors[err_id][
+                                            field_id]).lower())
                     if err_res is not None:
                         # if (k == 'traceback' or f != 'message'):
                         needed_msgs.add(all_errors[err_id][strid])
@@ -175,7 +179,6 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                         reasons[line_num] = set()
                     reasons[line_num].add('Many messages')
                     if (line_num in needed_msgs):
-                    #        and list(reasons[line_num]) == 1):
                         needed_msgs.remove(line_num)
             elif (len(events[filtered]['line_num']) == 1):
                 needed_msgs.add(events[filtered]['data'][0][strid])

--- a/src/lib/errors_statistics.py
+++ b/src/lib/errors_statistics.py
@@ -2,7 +2,7 @@
 """
 import numpy as np
 import re
-# from datetime import datetime
+from datetime import datetime
 
 
 def merge_all_errors_by_time(all_errors, fields_names):
@@ -55,7 +55,7 @@ def return_nonsimilar_part(str1, str2):
 
 
 def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
-                        user_hosts, dirname, err_timeline, vm_tasks,
+                        user_hosts, subtasks, dirname, err_timeline, vm_tasks,
                         long_tasks, all_vms, all_hosts):
     keywords = user_vms  # user_events + user_vms + user_hosts
     template = re.compile(\
@@ -101,6 +101,14 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                 if all_errors[err_id][strid] not in reasons.keys():
                     reasons[all_errors[err_id][strid]] = set()
                 reasons[all_errors[err_id][strid]].add('VM, Host or Task ID')
+        # print(subtasks)
+        for t in subtasks:
+            if t in all_errors[err_id][msid]:
+                # Check if user-defined words are in the message
+                needed_msgs.add(all_errors[err_id][strid])
+                if all_errors[err_id][strid] not in reasons.keys():
+                    reasons[all_errors[err_id][strid]] = set()
+                reasons[all_errors[err_id][strid]].add('Subtask')
         for k in ['error', 'fail', 'failure', 'failed', 'traceback',
                   'warn', 'warning', 'could not', 'exception', 'down',
                   'crash']:
@@ -130,12 +138,12 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                                                         shorten]['keywords'])
     events = new_events
     del new_events
-    # f = open("clusters_"+dirname.split('/')[-2]+".txt", 'w')
-    # for c_id, clust in enumerate(sorted(events.keys())):
-    #     for mes in events[clust]['data']:
-    #         f.write("%d : %s\n" % (c_id, mes[msid]))
-    #     f.write('\n')
-    # f.close()
+    f = open("clusters_"+dirname.split('/')[-2]+".txt", 'w')
+    for c_id, clust in enumerate(sorted(events.keys())):
+        for mes in events[clust]['data']:
+            f.write("%d : %s\n" % (c_id, mes[msid]))
+        f.write('\n')
+    f.close()
     out_descr.write('\n')
     mean_len = np.mean([len(events[g]['line_num']) for g in events.keys()])
     std_len = np.std([len(events[g]['line_num']) for g in events.keys()])
@@ -154,8 +162,8 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                 if line_num not in reasons.keys():
                     reasons[line_num] = set()
                 reasons[line_num].add('Many messages')
-                if (list(reasons[line_num]) == ['Many messages']
-                        and line_num in needed_msgs):
+                if (line_num in needed_msgs
+                        and 'Error or warning' not in list(reasons[line_num])):
                     needed_msgs.remove(line_num)
         elif (len(events[filtered]['line_num']) == 1):
             needed_msgs.add(events[filtered]['data'][0][strid])
@@ -167,27 +175,13 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
                 if line_num not in reasons.keys():
                     reasons[line_num] = set()
                 reasons[line_num].add('Rare')
-        # ----------------------------------------------
-        # if ((len(events[filtered]) > 2*mean_clust_len) and not
-        #         any([k in events[filtered][0][fid] for k in keywords])):
-        #     for msg in events[filtered]:
-        #         if msg[strid] not in reasons.keys():
-        #             reasons[msg[strid]] = set()
-        #         if (msg[strid] in needed_msgs):
-        #                 # and (len(reasons[msg[strid]]) == 0
-        #                 # or ('Many messages' in reasons[msg[strid]]))):
-        #                     # and 'Error or warning' not in
-        #                     # reasons[msg[strid]]))):
-        #             needed_msgs.remove(msg[strid])
-        #         reasons[msg[strid]].add('Frequent')
-        #     continue
         for msg in events[filtered]['data']:
             # Check if long tasks are related to the message
             for com in sorted(long_tasks.keys()):
                 added = False
                 for t in long_tasks[com]:
                     if ((com in msg[msid]) and
-                            (t - 10 < msg[dtid] < t + 10)):
+                            (msg[dtid] == t)):
                         needed_msgs.add(msg[strid])
                         if msg[strid] not in reasons.keys():
                             reasons[msg[strid]] = set()
@@ -199,18 +193,15 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
             # Check if message is related to the VM commands
             for field in msg:
                 added = False
-                # Show because includes keyword
-                # if any([k in str(field).lower() for k in
-                #        ['error ', 'fail', 'traceback',
-                #         'except', 'warn']]):
-                #    needed_msgs.add(msg[strid])
-                #    if msg[strid] not in reasons.keys():
-                #        reasons[msg[strid]] = set()
-                #    reasons[msg[strid]].add('Error or warning')
-                #    added = True
                 for thread in (vm_tasks.keys()):
                     if any([task['command_name'] in str(field)
                             for task in vm_tasks[thread]]):
+                        if (msg[strid] in reasons.keys()
+                                and 'Many messages' in reasons[msg[strid]]
+                                and 'Error or warning'
+                                not in reasons[msg[strid]]):
+                            reasons[msg[strid]].add('Task')
+                            break
                         needed_msgs.add(msg[strid])
                         if msg[strid] not in reasons.keys():
                             reasons[msg[strid]] = set()
@@ -232,25 +223,25 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
     new_fields = ['date_time', 'line_num', 'reason', 'message']
     if reasons == {}:
         return msg_showed, new_fields
-    # f = open('diff.txt', 'w')
-    # max_len = max([len('_'.join(reasons[r])) for r in reasons.keys()])
+    f = open('diff.txt', 'w')
+    max_len = max([len('_'.join(reasons[r])) for r in reasons.keys()])
     for msg in all_errors:
         if msg[strid] in needed_msgs:
             msg_showed += [[msg[dtid], msg[strid],
                             '_'.join(sorted(reasons[msg[strid]])),
                             msg[msid]]]
-    #     else:
-    #         if msg[strid] in reasons.keys():
-    #             reason = '_'.join(sorted(reasons[msg[strid]]))
-    #         else:
-    #             reason = 'unknown'
-    #         f.write("%12s %s | %20s | %*s | %s\n" %
-    #                 (datetime.utcfromtimestamp(msg[dtid]).strftime(
-    #                                                     "%H:%M:%S,%f")[:-3],
-    #                  datetime.utcfromtimestamp(msg[dtid]).strftime(
-    #                                                     "%d-%m-%Y"),
-    #                  msg[strid], max_len, reason, msg[msid]))
-    # f.close()
+        else:
+            if msg[strid] in reasons.keys():
+                reason = '_'.join(sorted(reasons[msg[strid]]))
+            else:
+                reason = 'unknown'
+            f.write("%12s %s | %20s | %*s | %s\n" %
+                    (datetime.utcfromtimestamp(msg[dtid]).strftime(
+                                                        "%H:%M:%S,%f")[:-3],
+                     datetime.utcfromtimestamp(msg[dtid]).strftime(
+                                                        "%d-%m-%Y"),
+                     msg[strid], max_len, reason, msg[msid]))
+    f.close()
     strid = new_fields.index('message')
     msg_showed = sorted(msg_showed, key=lambda k: k[0])
     prev_message = msg_showed[0][strid]
@@ -259,131 +250,3 @@ def clusterize_messages(out_descr, all_errors, fields, user_events, user_vms,
             msg_showed.remove(msg)
         prev_message = msg[strid]
     return msg_showed, new_fields
-
-
-# fields - names the following positions in log line (date_time,
-# massage, field1, field2, etc.). It is list.
-# all_errors [[msg, date_time, fields..., filtered], [],...]
-# clusters {'1': [msg_filtered, mgs_orig, time],...}
-# @profile
-# def calculate_events_frequency(out_descr, all_errors, clusters, fields,
-#                                err_timeline, keywords, vm_tasks, long_tasks,
-#                                all_vms, all_hosts, needed_msgs, reasons):
-#     msid = fields.index('message')
-#     dtid = fields.index('date_time')
-#     strid = fields.index('line_num')
-#     fid = fields.index('filtered')
-#     max_clust = max(clusters.keys())
-#     mean_clust_len = np.mean([len(clusters[c])
-#                               for c in set(clusters.keys())])
-#     for c_id in sorted(clusters.keys(), key=lambda k: int(k)):
-#         out_descr.write(("calculate_events_frequency: Cluster %s from %s") %
-#                          (c_id, max_clust), end='\r')
-#         if ((len(clusters[c_id]) > 2*mean_clust_len) and not
-#                 any([k in clusters[c_id][0][fid] for k in keywords])):
-#             for msg in clusters[c_id]:
-#                 if msg[strid] not in reasons.keys():
-#                     reasons[msg[strid]] = set()
-#                 if (msg[strid] in needed_msgs):
-#                         # and (len(reasons[msg[strid]]) == 0
-#                         # or ('Many messages' in reasons[msg[strid]]))):
-#                             # and 'Error or warning' not in
-#                             # reasons[msg[strid]]))):
-#                     needed_msgs.remove(msg[strid])
-#                 reasons[msg[strid]].add('Frequent')
-#             continue
-#         elif (len(clusters[c_id]) == 1):
-#             needed_msgs.add(clusters[c_id][0][strid])
-#             if clusters[c_id][0][strid] not in reasons.keys():
-#                 reasons[clusters[c_id][0][strid]] = set()
-#             reasons[clusters[c_id][0][strid]].add('Unique')
-#         elif (len(clusters[c_id]) < mean_clust_len/2):
-#             for msg in clusters[c_id]:
-#                 needed_msgs.add(msg[strid])
-#                 if msg[strid] not in reasons.keys():
-#                     reasons[msg[strid]] = set()
-#                 reasons[msg[strid]].add('Rare')
-#         for msg in clusters[c_id]:
-#             # Check if long tasks are related to the message
-#             for com in sorted(long_tasks.keys()):
-#                 added = False
-#                 for t in long_tasks[com]:
-#                     if ((com in msg[msid]) and
-#                             (t - 10 < msg[dtid] < t + 10)):
-#                         needed_msgs.add(msg[strid])
-#                         if msg[strid] not in reasons.keys():
-#                             reasons[msg[strid]] = set()
-#                         reasons[msg[strid]].add('Long operation')
-#                         added = True
-#                         break
-#                 if added:
-#                     break
-#             # Check if message is related to the VM commands
-#             for field in msg:
-#                 added = False
-#                 # Show because includes keyword
-#                 # if any([k in str(field).lower() for k in
-#                 #        ['error ', 'fail', 'traceback',
-#                 #         'except', 'warn']]):
-#                 #    needed_msgs.add(msg[strid])
-#                 #    if msg[strid] not in reasons.keys():
-#                 #        reasons[msg[strid]] = set()
-#                 #    reasons[msg[strid]].add('Error or warning')
-#                 #    added = True
-#                 for thread in (vm_tasks.keys()):
-#                     if any([task['command_name'] in str(field)
-#                             for task in vm_tasks[thread]]):
-#                         needed_msgs.add(msg[strid])
-#                         if msg[strid] not in reasons.keys():
-#                             reasons[msg[strid]] = set()
-#                         reasons[msg[strid]].add('Task')
-#                         added = True
-#                         break
-#                 if added:
-#                     break
-#             # TODO - filter
-#             # if (msg[strid] in reasons.keys() and 'Many messages' in
-#             #         reasons[msg[strid]] and ):
-#             #     pass
-#         # endloop
-#     # endloop
-#     print()
-#     for t in range(10, len(err_timeline)-10):
-#         if len(err_timeline[t-10:t]) < len(err_timeline[t:t+10]):
-#             # Show because an amount of followed messages increased
-#             for msg in err_timeline[t]:
-#                 needed_msgs.add(msg[strid])
-#                 if msg[strid] not in reasons.keys():
-#                     reasons[msg[strid]] = set()
-#                 reasons[msg[strid]].add('Increased errors')
-#     # END ALGO
-#     msg_showed = []
-#     new_fields = ['date_time', 'line_num', 'reason', 'message']
-#     if reasons == {}:
-#         return msg_showed, new_fields
-#     f = open('diff.txt', 'w')
-#     max_len = max([len('_'.join(reasons[r])) for r in reasons.keys()])
-#     for msg in all_errors:
-#         if msg[strid] in needed_msgs:
-#             msg_showed += [[msg[dtid], msg[strid],
-#                             '_'.join(sorted(reasons[msg[strid]])),
-#                             msg[msid]]]
-#         else:
-#             if msg[strid] in reasons.keys():
-#                 reason = '_'.join(sorted(reasons[msg[strid]]))
-#             else:
-#                 reason = 'unknown'
-#             f.write("%12s %s | %20s | %*s | %s\n" %
-#                     (datetime.utcfromtimestamp(msg[dtid]).strftime(
-#                                                         "%H:%M:%S,%f")[:-3],
-#                      datetime.utcfromtimestamp(msg[dtid]).strftime(
-#                                                         "%d-%m-%Y"),
-#                      msg[strid], max_len, reason, msg[msid]))
-#     f.close()
-#     msg_showed = sorted(msg_showed, key=lambda k: k[0])
-#     prev_message = msg_showed[0][3]
-#     for msg in (msg_showed[1:]).copy():
-#         if msg[3] == prev_message:
-#             msg_showed.remove(msg)
-#         prev_message = msg[3]
-#     return msg_showed, new_fields

--- a/src/lib/represent_statistics.py
+++ b/src/lib/represent_statistics.py
@@ -26,19 +26,24 @@ def print_only_dt_message(errors, new_fields, out):
     msg_idx = new_fields.index("message")
     reason_idx = new_fields.index("reason")
     details_idx = new_fields.index("details")
-
-    reason_len = max([len(r[reason_idx]) for r in errors])
+    reason = [err[reason_idx]
+              if err[details_idx] == ''
+              else err[details_idx] if err[reason_idx] == ''
+              else err[reason_idx] + '_' + err[details_idx]
+              for err in errors]
+    # reason_len = max([len(r[reason_idx]) for r in errors])
+    # details_len = max([len(r[details_idx]) for r in errors])
     linenum_len = max(len(err[line_idx]) for err in errors)
-    details_len = max([len(r[details_idx]) for r in errors])
-    out.write("%23s | %*s | %*s | %*s | %s\n" % ('Date+Time',
-              linenum_len, 'Line', reason_len, 'Reason', details_len,
-              'Details', 'Message'))
-    out.write('-'*(29+linenum_len+reason_len+details_len+50)+'\n')
+    full_reason_len = max([len(reason[r]) for r in range(len(reason))])
+    out.write("%23s | %*s | %*s | %s\n" % ('Date+Time',
+              linenum_len, 'Line', full_reason_len,
+              'Reason', 'Message'))
+    out.write('-'*(29+linenum_len+full_reason_len+50)+'\n')
     for idx, err in enumerate(errors):
-        out.write("%12s %s | %*s | %*s | %*s | %s\n" %
+        out.write("%12s %s | %*s | %*s | %s\n" %
                   (datetime.utcfromtimestamp(err[dt_idx]).strftime(
                    "%H:%M:%S,%f")[:-3],
                    datetime.utcfromtimestamp(err[dt_idx]).strftime(
                    "%d-%m-%Y"),
-                   linenum_len, err[line_idx], reason_len, err[reason_idx],
-                   details_len, err[details_idx], err[msg_idx]))
+                   linenum_len, err[line_idx], full_reason_len,
+                   reason[idx], err[msg_idx]))

--- a/src/lib/represent_statistics.py
+++ b/src/lib/represent_statistics.py
@@ -20,20 +20,24 @@ def print_all_headers(errors, headers, log_format_headers, out):
 def print_only_dt_message(errors, new_fields, out):
     if errors == []:
         return
+
     dt_idx = new_fields.index("date_time")
     line_idx = new_fields.index("line_num")
     msg_idx = new_fields.index("message")
     reason_idx = new_fields.index("reason")
+    details_idx = new_fields.index("details")
+
     reason_len = max([len(r[reason_idx]) for r in errors])
-    max_len = max(len(err[line_idx]) for err in errors)
-    out.write("%23s | %*s | %*s | %s\n" % ('Date+Time', max_len, 'Line',
-              reason_len, 'Reason', 'Message'))
-    out.write('-'*(29+max_len+reason_len+50)+'\n')
+    linenum_len = max(len(err[line_idx]) for err in errors)
+    details_len = max([len(r[details_idx]) for r in errors])
+    out.write("%23s | %*s | %*s | %*s | %s\n" % ('Date+Time', linenum_len, 'Line',
+              reason_len, 'Reason', details_len, 'Details', 'Message'))
+    out.write('-'*(29+linenum_len+reason_len+details_len+50)+'\n')
     for idx, err in enumerate(errors):
-        out.write("%12s %s | %*s | %*s | %s\n" %
+        out.write("%12s %s | %*s | %*s | %*s | %s\n" %
                   (datetime.utcfromtimestamp(err[dt_idx]).strftime(
                    "%H:%M:%S,%f")[:-3],
                    datetime.utcfromtimestamp(err[dt_idx]).strftime(
                    "%d-%m-%Y"),
-                   max_len, err[line_idx], reason_len, err[reason_idx],
-                   err[msg_idx]))
+                   linenum_len, err[line_idx], reason_len, err[reason_idx],
+                   details_len, err[details_idx], err[msg_idx]))

--- a/src/lib/represent_statistics.py
+++ b/src/lib/represent_statistics.py
@@ -30,8 +30,9 @@ def print_only_dt_message(errors, new_fields, out):
     reason_len = max([len(r[reason_idx]) for r in errors])
     linenum_len = max(len(err[line_idx]) for err in errors)
     details_len = max([len(r[details_idx]) for r in errors])
-    out.write("%23s | %*s | %*s | %*s | %s\n" % ('Date+Time', linenum_len, 'Line',
-              reason_len, 'Reason', details_len, 'Details', 'Message'))
+    out.write("%23s | %*s | %*s | %*s | %s\n" % ('Date+Time',
+              linenum_len, 'Line', reason_len, 'Reason', details_len,
+              'Details', 'Message'))
     out.write('-'*(29+linenum_len+reason_len+details_len+50)+'\n')
     for idx, err in enumerate(errors):
         out.write("%12s %s | %*s | %*s | %*s | %s\n" %


### PR DESCRIPTION
1. Added detection of task nesting level (+added to the output)
2. Added VM, Host ID to the output
3. Added ability to choose criterias for messages to be shown (for example, if you want to see only errors, or with long operations, etc.)
4. Detection of VM's migration timeline (now without --additive flag the analyser shows messages not only with both VM and host in the line, but if the VM was on the host in this time)
5. Added detection of long operations for qemu monitor in libvirt-logs
6. Added tasks duration to the output
7. All json files are dumped -> use -d flag (-d directory_name) to put all the analyser's produced files to a new directory
8. Fixed bugs